### PR TITLE
feature:  [Toggle colores caducidad en InventarioView](#001)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 .DS_Store
 *.db
+.vscode/

--- a/Refactorizacion-ALFA/src/main/java/view/InventarioView.java
+++ b/Refactorizacion-ALFA/src/main/java/view/InventarioView.java
@@ -132,6 +132,11 @@ public class InventarioView {
         leftPanel.add(btnBuscar);
 
         JPanel rightPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+        /*
+            * Toggle para activar/desactivar colores de caducidad.
+             * Esto permite a los usuarios que prefieren una tabla sin colores (por ejemplo, por accesibilidad)
+             * desactivar esta función sin perder la funcionalidad de hover.
+        */
         JToggleButton btnToggleColores = new JToggleButton("Colores caducidad: ON");
         btnToggleColores.setSelected(true);
         btnToggleColores.setFont(new Font("Arial", Font.BOLD, 14));
@@ -376,6 +381,11 @@ public class InventarioView {
             this.hoveredRow = row;
         }
 
+        /*
+            * Permite activar o desactivar los colores de caducidad.
+             * Esto es útil para usuarios que prefieren una tabla sin colores (por ejemplo, por accesibilidad).
+             * Al desactivar los colores, la función de hover sigue funcionando normalmente.
+        */
         public void setMostrarColores(boolean mostrar) {
             this.mostrarColores = mostrar;
         }

--- a/Refactorizacion-ALFA/src/main/java/view/InventarioView.java
+++ b/Refactorizacion-ALFA/src/main/java/view/InventarioView.java
@@ -1,10 +1,16 @@
 package view;
 
-import controller.InventarioController;
-import javax.swing.*;
-import javax.swing.table.*;
-import java.awt.*;
-import java.awt.event.*;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Cursor;
+import java.awt.FlowLayout;
+import java.awt.Font;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseMotionAdapter;
 import java.io.File;
 import java.time.LocalDate;
 import java.time.YearMonth;
@@ -12,6 +18,26 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+
+import javax.swing.BorderFactory;
+import javax.swing.JButton;
+import javax.swing.JFileChooser;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.JTextField;
+import javax.swing.JToggleButton;
+import javax.swing.ListSelectionModel;
+import javax.swing.RowFilter;
+import javax.swing.SwingUtilities;
+import javax.swing.table.DefaultTableCellRenderer;
+import javax.swing.table.DefaultTableModel;
+import javax.swing.table.TableRowSorter;
+
+import controller.InventarioController;
 
 public class InventarioView {
     private JFrame frame;
@@ -106,6 +132,21 @@ public class InventarioView {
         leftPanel.add(btnBuscar);
 
         JPanel rightPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+        JToggleButton btnToggleColores = new JToggleButton("Colores caducidad: ON");
+        btnToggleColores.setSelected(true);
+        btnToggleColores.setFont(new Font("Arial", Font.BOLD, 14));
+        btnToggleColores.setFocusPainted(false);
+        btnToggleColores.setBackground(new Color(30, 136, 229));
+        btnToggleColores.setForeground(Color.WHITE);
+        btnToggleColores.setBorder(BorderFactory.createEmptyBorder(10, 15, 10, 15));
+        btnToggleColores.addActionListener(e -> {
+            boolean activo = btnToggleColores.isSelected();
+            btnToggleColores.setText(activo ? "Colores caducidad: ON" : "Colores caducidad: OFF");
+            btnToggleColores.setBackground(activo ? new Color(30, 136, 229) : new Color(100, 100, 100));
+            hoverRenderer.setMostrarColores(activo);
+            table.repaint();
+        });
+        rightPanel.add(btnToggleColores);
         JButton btnRefrescar = createButton("Refrescar", "");
         addHoverEffect(btnRefrescar);
         rightPanel.add(btnRefrescar);
@@ -329,9 +370,14 @@ public class InventarioView {
      */
     private static class HoverTableCellRenderer extends DefaultTableCellRenderer {
         private int hoveredRow = -1;
+        private boolean mostrarColores = true;
 
         public void setHoveredRow(int row) {
             this.hoveredRow = row;
+        }
+
+        public void setMostrarColores(boolean mostrar) {
+            this.mostrarColores = mostrar;
         }
 
         @Override
@@ -352,9 +398,9 @@ public class InventarioView {
                     LocalDate hoy = LocalDate.now();
                     long diasRestantes = ChronoUnit.DAYS.between(hoy, primerDiaCaducidad);
 
-                    if (diasRestantes < 0) {
+                    if (mostrarColores &&diasRestantes < 0) {
                         c.setBackground(new Color(255, 0, 0)); // Rojo fuerte (ya caducado)
-                    } else if (diasRestantes <= 30) {
+                    } else if (mostrarColores && diasRestantes <= 30) {
                         c.setBackground(new Color(255, 153, 153)); // Rojo claro (próximo a caducar)
                     } else if (row == hoveredRow && !isSelected) {
                         c.setBackground(new Color(220, 240, 255)); // Hover

--- a/Refactorizacion-ALFA/src/main/java/view/InventarioView.java
+++ b/Refactorizacion-ALFA/src/main/java/view/InventarioView.java
@@ -368,7 +368,7 @@ public class InventarioView {
      * - Se marca con rojo fuerte si el producto ya caducó.
      * - Se marca con rojo claro si está próximo a caducar (dentro de 30 días).
      */
-    private static class HoverTableCellRenderer extends DefaultTableCellRenderer {
+    static class HoverTableCellRenderer extends DefaultTableCellRenderer {
         private int hoveredRow = -1;
         private boolean mostrarColores = true;
 

--- a/Refactorizacion-ALFA/src/test/java/view/HoverTableCellRendererTest.java
+++ b/Refactorizacion-ALFA/src/test/java/view/HoverTableCellRendererTest.java
@@ -1,0 +1,201 @@
+package view;
+
+import java.awt.Color;
+import java.awt.Component;
+import java.lang.reflect.Field;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+
+import javax.swing.JTable;
+import javax.swing.table.DefaultTableModel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * PRU-001-01 — Pruebas Unitarias para HoverTableCellRenderer (MR-001)
+ *
+ * Verifica que el toggle de colores de caducidad funciona correctamente
+ * a nivel de componente, sin depender de la vista completa.
+ */
+@DisplayName("PRU-001-01 | HoverTableCellRenderer — Toggle colores caducidad (MR-001)")
+class HoverTableCellRendererTest {
+
+    @BeforeAll
+    static void configurarModoHeadless() {
+        System.setProperty("java.awt.headless", "true");
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private InventarioView.HoverTableCellRenderer crearRenderer() {
+        return new InventarioView.HoverTableCellRenderer();
+    }
+
+    private JTable crearTabla(String fechaCaducidad) {
+        DefaultTableModel model = new DefaultTableModel(
+                new String[]{"ID", "Nombre", "Existencias", "Lote", "Caducidad", "Fecha Entrada"}, 0
+        );
+        model.addRow(new Object[]{1, "Medicamento Test", "10", "L001", fechaCaducidad, "2025-01-01"});
+        return new JTable(model);
+    }
+
+    private boolean leerCampoMostrarColores(InventarioView.HoverTableCellRenderer renderer)
+            throws Exception {
+        Field field = InventarioView.HoverTableCellRenderer.class.getDeclaredField("mostrarColores");
+        field.setAccessible(true);
+        return (boolean) field.get(renderer);
+    }
+
+    /** Devuelve una fecha "yyyy-MM" cuyo primer día ya pasó (producto caducado). */
+    private String fechaCaducada() {
+        return YearMonth.now().minusMonths(2).format(DateTimeFormatter.ofPattern("yyyy-MM"));
+    }
+
+    /**
+     * Devuelve una fecha "yyyy-MM" cuyo primer día está entre 1 y 30 días
+     * en el futuro (producto próximo a caducar).
+     * Busca en los próximos 3 meses para cubrir bordes de mes.
+     */
+    private String fechaProximaCaducidad() {
+        LocalDate hoy = LocalDate.now();
+        for (int i = 0; i <= 3; i++) {
+            YearMonth ym = YearMonth.now().plusMonths(i);
+            long dias = ChronoUnit.DAYS.between(hoy, ym.atDay(1));
+            if (dias >= 1 && dias <= 30) {
+                return ym.format(DateTimeFormatter.ofPattern("yyyy-MM"));
+            }
+        }
+        // Fallback: si no encuentra ninguno, usa el mes siguiente de todos modos
+        return YearMonth.now().plusMonths(1).format(DateTimeFormatter.ofPattern("yyyy-MM"));
+    }
+
+    // -------------------------------------------------------------------------
+    // TC-01: setMostrarColores(false) actualiza el campo interno
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("TC-01: setMostrarColores(false) → campo mostrarColores vale false")
+    void tc01_setMostrarColoresFalse_campoEsFalse() throws Exception {
+        InventarioView.HoverTableCellRenderer renderer = crearRenderer();
+
+        renderer.setMostrarColores(false);
+
+        assertFalse(leerCampoMostrarColores(renderer),
+                "Después de setMostrarColores(false), el campo debe ser false");
+    }
+
+    // -------------------------------------------------------------------------
+    // TC-02: setMostrarColores(true) actualiza el campo interno
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("TC-02: setMostrarColores(true) → campo mostrarColores vale true")
+    void tc02_setMostrarColoresTrue_campoEsTrue() throws Exception {
+        InventarioView.HoverTableCellRenderer renderer = crearRenderer();
+        renderer.setMostrarColores(false); // estado previo: desactivado
+
+        renderer.setMostrarColores(true);
+
+        assertTrue(leerCampoMostrarColores(renderer),
+                "Después de setMostrarColores(true), el campo debe ser true");
+    }
+
+    // -------------------------------------------------------------------------
+    // TC-03: Producto caducado + colores ON → fondo rojo fuerte (255, 0, 0)
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("TC-03: Producto caducado + colores ON → fondo (255, 0, 0)")
+    void tc03_productoCaducado_coloresActivos_fondoRojoFuerte() {
+        String fecha = fechaCaducada();
+        JTable tabla = crearTabla(fecha);
+        InventarioView.HoverTableCellRenderer renderer = crearRenderer();
+
+        renderer.setMostrarColores(true);
+        Component celda = renderer.getTableCellRendererComponent(tabla, fecha, false, false, 0, 4);
+
+        assertEquals(new Color(255, 0, 0), celda.getBackground(),
+                "Producto caducado con colores ON debe mostrar rojo fuerte");
+    }
+
+    // -------------------------------------------------------------------------
+    // TC-04: Producto caducado + colores OFF → sin rojo
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("TC-04: Producto caducado + colores OFF → fondo normal (sin rojo)")
+    void tc04_productoCaducado_coloresInactivos_sinRojo() {
+        String fecha = fechaCaducada();
+        JTable tabla = crearTabla(fecha);
+        InventarioView.HoverTableCellRenderer renderer = crearRenderer();
+
+        renderer.setMostrarColores(false);
+        Component celda = renderer.getTableCellRendererComponent(tabla, fecha, false, false, 0, 4);
+
+        assertNotEquals(new Color(255, 0, 0), celda.getBackground(),
+                "Producto caducado con colores OFF no debe mostrar rojo fuerte");
+        assertNotEquals(new Color(255, 153, 153), celda.getBackground(),
+                "Producto caducado con colores OFF no debe mostrar rojo claro");
+    }
+
+    // -------------------------------------------------------------------------
+    // TC-05: Producto próximo a caducar + colores ON → fondo rojo claro (255, 153, 153)
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("TC-05: Producto próximo a caducar + colores ON → fondo (255, 153, 153)")
+    void tc05_productoProximo_coloresActivos_fondoRojoClaro() {
+        String fecha = fechaProximaCaducidad();
+        JTable tabla = crearTabla(fecha);
+        InventarioView.HoverTableCellRenderer renderer = crearRenderer();
+
+        renderer.setMostrarColores(true);
+        Component celda = renderer.getTableCellRendererComponent(tabla, fecha, false, false, 0, 4);
+
+        assertEquals(new Color(255, 153, 153), celda.getBackground(),
+                "Producto próximo a caducar con colores ON debe mostrar rojo claro");
+    }
+
+    // -------------------------------------------------------------------------
+    // TC-06: Producto próximo a caducar + colores OFF → sin rojo
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("TC-06: Producto próximo a caducar + colores OFF → fondo normal (sin rojo)")
+    void tc06_productoProximo_coloresInactivos_sinRojo() {
+        String fecha = fechaProximaCaducidad();
+        JTable tabla = crearTabla(fecha);
+        InventarioView.HoverTableCellRenderer renderer = crearRenderer();
+
+        renderer.setMostrarColores(false);
+        Component celda = renderer.getTableCellRendererComponent(tabla, fecha, false, false, 0, 4);
+
+        assertNotEquals(new Color(255, 0, 0), celda.getBackground(),
+                "Producto próximo a caducar con colores OFF no debe mostrar rojo fuerte");
+        assertNotEquals(new Color(255, 153, 153), celda.getBackground(),
+                "Producto próximo a caducar con colores OFF no debe mostrar rojo claro");
+    }
+
+    // -------------------------------------------------------------------------
+    // TC-07: Estado inicial por defecto → mostrarColores es true
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("TC-07: Estado inicial → mostrarColores es true por defecto")
+    void tc07_estadoInicial_mostrarColoresEsTrue() throws Exception {
+        InventarioView.HoverTableCellRenderer renderer = crearRenderer();
+
+        assertTrue(leerCampoMostrarColores(renderer),
+                "Al crear el renderer, mostrarColores debe ser true (comportamiento original)");
+    }
+}


### PR DESCRIPTION
### Cambios
- Añade \`JToggleButton\` en panel superior derecho de \`InventarioView\`
- Controla el resaltado rojo de productos caducados y próximos a caducar
- Estado ON (azul): colores activos — Estado OFF (gris): sin colores
- Sin cambios en Controller ni DAO

### Pruebas
- 7 pruebas unitarias (PRU-001-01): todas pasaron ✓
- Ver Plantillas 9 para casos funcionales y de regresión en la sub carpeta del MR en el canal de Teams (PRU-001-01 / PRU-001-02 / PRU-001-03)