### PR TITLE
feature: [Campo de búsqueda unificado](#002)

### DIFF
--- a/Refactorizacion-ALFA/src/main/java/controller/InventarioController.java
+++ b/Refactorizacion-ALFA/src/main/java/controller/InventarioController.java
@@ -2,6 +2,7 @@ package controller;
 
 import java.io.File;
 import java.util.List;
+
 import model.InventarioDAO;
 
 public class InventarioController {
@@ -120,6 +121,21 @@ public class InventarioController {
         return dao.obtenerProductoIdPorNombre(dato);
     }
 
+    /**
+     * [MR-002 – OPC-A] Wrapper que delega la búsqueda unificada al DAO.
+     *
+     * <p>Permite a la vista obtener el {@code id} y {@code nombre} reales de un
+     * producto ingresando únicamente un ID numérico o el nombre exacto del
+     * medicamento, sin necesidad de conocer la lógica de acceso a datos.
+     *
+     * @param dato Cadena ingresada por el usuario (ID numérico o nombre exacto).
+     * @return {@code Object[]{id, nombre}} si el producto existe,
+     *         {@code null} si no se encontró ninguna coincidencia.
+     * @see model.InventarioDAO#buscarProductoPorIdONombre(String)
+     */
+    public Object[] buscarProductoPorIdONombre(String dato) {
+        return dao.buscarProductoPorIdONombre(dato);
+    }
 
 
     public boolean eliminarApartado(int id) {

--- a/Refactorizacion-ALFA/src/main/java/model/InventarioDAO.java
+++ b/Refactorizacion-ALFA/src/main/java/model/InventarioDAO.java
@@ -2,7 +2,12 @@ package model;
 
 import java.io.File;
 import java.io.FileWriter;
-import java.sql.*;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.time.LocalDate;
 import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
@@ -10,7 +15,8 @@ import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
-import javax.swing.*;
+
+import javax.swing.JOptionPane;
 
 public class InventarioDAO {
 
@@ -628,6 +634,54 @@ public class InventarioDAO {
         }
         return -1; // Retorna -1 si no se encuentra el producto.
     }
+
+    /**
+     * [MR-002 – OPC-A] Busca un producto por ID numérico exacto o por nombre exacto.
+     *
+     * <p>Estrategia de búsqueda:
+     * <ol>
+     *   <li>Intenta parsear {@code dato} como entero; si lo logra, ejecuta
+     *       {@code SELECT id, nombre FROM productos WHERE id = ?}.</li>
+     *   <li>Si el parseo falla ({@link NumberFormatException}) o no hay resultado,
+     *       ejecuta {@code SELECT id, nombre FROM productos WHERE nombre = ?}
+     *       (coincidencia exacta, sin comodines).</li>
+     * </ol>
+     *
+     * @param dato Cadena ingresada por el usuario; puede ser un ID numérico o
+     *             el nombre exacto del medicamento.
+     * @return {@code Object[]{id, nombre}} si se encuentra el producto,
+     *         {@code null} si no existe ninguna coincidencia.
+     */
+    public Object[] buscarProductoPorIdONombre(String dato) {
+        try {
+            ensureConnection();
+            try {
+                int id = Integer.parseInt(dato.trim());
+                String sql = "SELECT id, nombre FROM productos WHERE id = ?";
+                try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+                    stmt.setInt(1, id);
+                    ResultSet rs = stmt.executeQuery();
+                    if (rs.next()) {
+                        return new Object[]{rs.getInt("id"), rs.getString("nombre")};
+                    }
+                }
+            } catch (NumberFormatException e) {
+                // El dato no es un número; buscar por nombre exacto
+            }
+            String sql = "SELECT id, nombre FROM productos WHERE nombre = ?";
+            try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+                stmt.setString(1, dato.trim());
+                ResultSet rs = stmt.executeQuery();
+                if (rs.next()) {
+                    return new Object[]{rs.getInt("id"), rs.getString("nombre")};
+                }
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
 
 
     public boolean eliminarApartado(int id) {

--- a/Refactorizacion-ALFA/src/main/java/view/RegistrarVentaView.java
+++ b/Refactorizacion-ALFA/src/main/java/view/RegistrarVentaView.java
@@ -4,11 +4,19 @@ import controller.InventarioController;
 import javax.swing.*;
 import java.awt.*;
 
+/**
+ * [MR-002 – OPC-A] Diálogo para registrar una venta.
+ *
+ * <p>Reemplaza los campos separados {@code txtId} y {@code txtNombre} por un
+ * único campo {@code txtBusqueda} que acepta el ID numérico o el nombre exacto
+ * del medicamento. La resolución del producto se delega al controlador.
+ */
 public class RegistrarVentaView extends JDialog {
-    private JTextField txtId, txtNombre;
+    /** [MR-002 – OPC-A] Campo unificado: acepta ID numérico o nombre exacto del medicamento. */
+    private JTextField txtBusqueda;
     private JSpinner spinnerCantidad; // Reemplaza txtCantidad
-    private InventarioController controller;
-    private VentasView parentView;
+    private final InventarioController controller;
+    private final VentasView parentView;
 
     public RegistrarVentaView(VentasView parentView, InventarioController controller) {
         super(parentView, "Agregar Venta", true);
@@ -29,28 +37,16 @@ public class RegistrarVentaView extends JDialog {
         gbc.fill = GridBagConstraints.HORIZONTAL;
 
         // Etiqueta y campo para el ID
-        JLabel lblId = new JLabel("ID del Medicamento:");
-        lblId.setFont(new Font("Arial", Font.BOLD, 14));
+        JLabel lblBusqueda = new JLabel("ID o Nombre del Medicamento:");
+        lblBusqueda.setFont(new Font("Arial", Font.BOLD, 14));
         gbc.gridx = 0;
         gbc.gridy = 0;
-        panel.add(lblId, gbc);
+        panel.add(lblBusqueda, gbc);
 
-        txtId = new JTextField(15);
-        txtId.setFont(new Font("Arial", Font.PLAIN, 14));
+        txtBusqueda = new JTextField(15);
+        txtBusqueda.setFont(new Font("Arial", Font.PLAIN, 14));
         gbc.gridx = 1;
-        panel.add(txtId, gbc);
-
-        // Etiqueta y campo para el Nombre
-        JLabel lblNombre = new JLabel("Nombre del Medicamento:");
-        lblNombre.setFont(new Font("Arial", Font.BOLD, 14));
-        gbc.gridx = 0;
-        gbc.gridy = 1;
-        panel.add(lblNombre, gbc);
-
-        txtNombre = new JTextField(15);
-        txtNombre.setFont(new Font("Arial", Font.PLAIN, 14));
-        gbc.gridx = 1;
-        panel.add(txtNombre, gbc);
+        panel.add(txtBusqueda, gbc);
 
         // Etiqueta y campo para la Cantidad
         JLabel lblCantidad = new JLabel("Cantidad Vendida:");
@@ -102,24 +98,43 @@ public class RegistrarVentaView extends JDialog {
         return button;
     }
 
+    /**
+     * [MR-002 – OPC-A] Procesa el registro de una venta usando el campo unificado.
+     *
+     * <p>Flujo:
+     * <ol>
+     *   <li>Valida que {@code txtBusqueda} y la cantidad no estén vacíos.</li>
+     *   <li>Llama a {@link controller.InventarioController#buscarProductoPorIdONombre(String)}
+     *       con el texto ingresado.</li>
+     *   <li>Si el resultado es {@code null}, muestra un mensaje de error y
+     *       aborta sin registrar la venta.</li>
+     *   <li>Extrae {@code id} y {@code nombre} del arreglo retornado y delega
+     *       a {@link controller.InventarioController#registrarVenta(int, String, int)}.</li>
+     * </ol>
+     */
     private void registrarVenta() {
-        String idStr = txtId.getText().trim();
-        String nombre = txtNombre.getText().trim();
-        // Obtenemos el valor del spinner y lo convertimos a String
+        String busqueda = txtBusqueda.getText().trim();
         Object spinnerValue = spinnerCantidad.getValue();
         String cantidadStr = spinnerValue != null ? spinnerValue.toString() : "";
 
-        if (idStr.isEmpty() || nombre.isEmpty() || cantidadStr.isEmpty()) {
+        if (busqueda.isEmpty() || cantidadStr.isEmpty()) {
             JOptionPane.showMessageDialog(this, "Todos los campos son obligatorios.", "Error", JOptionPane.ERROR_MESSAGE);
             return;
         }
+
+        Object[] producto = controller.buscarProductoPorIdONombre(busqueda);
+        if (producto == null) {
+            JOptionPane.showMessageDialog(this,
+                "No se encontró ningún medicamento con el ID o nombre ingresado.",
+                "Error", JOptionPane.ERROR_MESSAGE);
+            return;
+        }
+
         try {
-            int id = Integer.parseInt(idStr);
+            int id = (int) producto[0];
+            String nombre = (String) producto[1];
             int cantidad = Integer.parseInt(cantidadStr);
-            if (cantidad <= 0) {
-                JOptionPane.showMessageDialog(this, "La cantidad debe ser mayor a cero.", "Error", JOptionPane.ERROR_MESSAGE);
-                return;
-            }
+
             if (controller.registrarVenta(id, nombre, cantidad)) {
                 JOptionPane.showMessageDialog(this, "Venta registrada con éxito.");
                 parentView.actualizarTabla();
@@ -128,7 +143,7 @@ public class RegistrarVentaView extends JDialog {
                 JOptionPane.showMessageDialog(this, "Error al registrar la venta.", "Error", JOptionPane.ERROR_MESSAGE);
             }
         } catch (NumberFormatException e) {
-            JOptionPane.showMessageDialog(this, "El ID y la cantidad deben ser números válidos.", "Error", JOptionPane.ERROR_MESSAGE);
+            JOptionPane.showMessageDialog(this, "La cantidad debe ser un número válido.", "Error", JOptionPane.ERROR_MESSAGE);
         }
     }
 }

--- a/Refactorizacion-ALFA/src/test/java/controller/InventarioControllerBusquedaTest.java
+++ b/Refactorizacion-ALFA/src/test/java/controller/InventarioControllerBusquedaTest.java
@@ -1,0 +1,144 @@
+package controller;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import org.junit.jupiter.api.AfterEach;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import model.InventarioDAO;
+
+/**
+ * PRU-002-02 — Pruebas Unitarias para InventarioController.buscarProductoPorIdONombre (MR-002)
+ *
+ * Verifica que el método wrapper del controlador delegue correctamente al DAO
+ * y propague el resultado sin alterarlo, usando una BD SQLite en memoria.
+ */
+@DisplayName("PRU-002-02 | InventarioController — buscarProductoPorIdONombre (MR-002)")
+class InventarioControllerBusquedaTest {
+
+    private Connection connection;
+    private InventarioDAO dao;
+    private InventarioController controller;
+
+    // -------------------------------------------------------------------------
+    // Ciclo de vida
+    // -------------------------------------------------------------------------
+
+    @BeforeEach
+    void setUp() throws SQLException {
+        connection = DriverManager.getConnection("jdbc:sqlite::memory:");
+        crearEsquema();
+        insertarProductosDePrueba();
+        dao = new InventarioDAO(connection);
+        controller = new InventarioController(dao);
+    }
+
+    @AfterEach
+    void tearDown() throws SQLException {
+        if (connection != null && !connection.isClosed()) {
+            connection.close();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private void crearEsquema() throws SQLException {
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute(
+                "CREATE TABLE IF NOT EXISTS productos (" +
+                "id INTEGER PRIMARY KEY AUTOINCREMENT, " +
+                "nombre TEXT, existencias INTEGER, lote TEXT, " +
+                "caducidad TEXT, fechaEntrada TEXT, fecha_separado TEXT)"
+            );
+        }
+    }
+
+    private void insertarProductosDePrueba() throws SQLException {
+        String sql = "INSERT INTO productos (nombre, existencias, lote, caducidad, fechaEntrada) VALUES (?, ?, ?, ?, ?)";
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setString(1, "Amoxicilina"); ps.setInt(2, 50);
+            ps.setString(3, "L001"); ps.setString(4, "2026-12"); ps.setString(5, "2025-01-01");
+            ps.executeUpdate();
+
+            ps.setString(1, "Ibuprofeno"); ps.setInt(2, 20);
+            ps.setString(3, "L003"); ps.setString(4, "2027-03"); ps.setString(5, "2025-01-01");
+            ps.executeUpdate();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // TC-01: Búsqueda por ID → el controller propaga el resultado del DAO
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("TC-01: Búsqueda por ID numérico → el controller retorna el mismo arreglo que el DAO")
+    void tc01_busquedaPorId_propagaResultadoDelDao() {
+        Object[] resultado = controller.buscarProductoPorIdONombre("1");
+
+        assertNotNull(resultado, "El controller debe propagar el resultado no-null del DAO");
+        assertEquals(1,             resultado[0], "El id debe ser 1");
+        assertEquals("Amoxicilina", resultado[1], "El nombre debe ser Amoxicilina");
+    }
+
+    // -------------------------------------------------------------------------
+    // TC-02: Búsqueda por nombre exacto → el controller propaga el resultado del DAO
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("TC-02: Búsqueda por nombre exacto → el controller retorna el mismo arreglo que el DAO")
+    void tc02_busquedaPorNombre_propagaResultadoDelDao() {
+        Object[] resultado = controller.buscarProductoPorIdONombre("Ibuprofeno");
+
+        assertNotNull(resultado, "El controller debe propagar el resultado no-null del DAO");
+        assertEquals("Ibuprofeno", resultado[1], "El nombre debe ser Ibuprofeno");
+    }
+
+    // -------------------------------------------------------------------------
+    // TC-03: Sin coincidencia → el controller propaga el null del DAO
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("TC-03: Sin coincidencia → el controller retorna null (propaga el null del DAO)")
+    void tc03_sinCoincidencia_propagaNullDelDao() {
+        Object[] resultado = controller.buscarProductoPorIdONombre("MedicamentoNoExiste");
+
+        assertNull(resultado, "El controller debe propagar null cuando el DAO no encuentra resultado");
+    }
+
+    // -------------------------------------------------------------------------
+    // TC-04: El resultado tiene exactamente 2 elementos sin transformación
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("TC-04: El controller no transforma el arreglo; retorna {id, nombre} intacto")
+    void tc04_resultadoNoEsTransformado() {
+        Object[] resultado = controller.buscarProductoPorIdONombre("Amoxicilina");
+
+        assertNotNull(resultado);
+        assertEquals(2, resultado.length, "El wrapper no debe modificar la longitud del arreglo");
+    }
+
+    // -------------------------------------------------------------------------
+    // TC-05: Nombre parcial → null propagado correctamente
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("TC-05: Nombre parcial → null (el controller no añade lógica de coincidencia parcial)")
+    void tc05_nombreParcial_propagaNullDelDao() {
+        Object[] resultado = controller.buscarProductoPorIdONombre("Amox");
+
+        assertNull(resultado,
+            "El controller es un wrapper puro; no debe añadir lógica de búsqueda parcial");
+    }
+}

--- a/Refactorizacion-ALFA/src/test/java/model/InventarioDAOBusquedaTest.java
+++ b/Refactorizacion-ALFA/src/test/java/model/InventarioDAOBusquedaTest.java
@@ -1,0 +1,181 @@
+package model;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import org.junit.jupiter.api.AfterEach;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * PRU-002-01 — Pruebas Unitarias para InventarioDAO.buscarProductoPorIdONombre (MR-002)
+ *
+ * Verifica la lógica de búsqueda dual (ID numérico o nombre exacto) del DAO
+ * usando una base de datos SQLite en memoria para aislamiento total.
+ */
+@DisplayName("PRU-002-01 | InventarioDAO — buscarProductoPorIdONombre (MR-002)")
+class InventarioDAOBusquedaTest {
+
+    private Connection connection;
+    private InventarioDAO dao;
+
+    // -------------------------------------------------------------------------
+    // Ciclo de vida
+    // -------------------------------------------------------------------------
+
+    @BeforeEach
+    void setUp() throws SQLException {
+        connection = DriverManager.getConnection("jdbc:sqlite::memory:");
+        crearEsquema();
+        insertarProductosDePrueba();
+        dao = new InventarioDAO(connection);
+    }
+
+    @AfterEach
+    void tearDown() throws SQLException {
+        if (connection != null && !connection.isClosed()) {
+            connection.close();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private void crearEsquema() throws SQLException {
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute(
+                "CREATE TABLE IF NOT EXISTS productos (" +
+                "id INTEGER PRIMARY KEY AUTOINCREMENT, " +
+                "nombre TEXT, existencias INTEGER, lote TEXT, " +
+                "caducidad TEXT, fechaEntrada TEXT, fecha_separado TEXT)"
+            );
+        }
+    }
+
+    private void insertarProductosDePrueba() throws SQLException {
+        String sql = "INSERT INTO productos (nombre, existencias, lote, caducidad, fechaEntrada) VALUES (?, ?, ?, ?, ?)";
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setString(1, "Amoxicilina"); ps.setInt(2, 50);
+            ps.setString(3, "L001"); ps.setString(4, "2026-12"); ps.setString(5, "2025-01-01");
+            ps.executeUpdate();
+
+            ps.setString(1, "Paracetamol"); ps.setInt(2, 30);
+            ps.setString(3, "L002"); ps.setString(4, "2027-06"); ps.setString(5, "2025-01-01");
+            ps.executeUpdate();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // TC-01: Búsqueda por ID numérico válido
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("TC-01: ID numérico válido → retorna Object[]{id, nombre} correcto")
+    void tc01_idNumericoValido_retornaProducto() {
+        Object[] resultado = dao.buscarProductoPorIdONombre("1");
+
+        assertNotNull(resultado, "Con id=1 existente debe retornar un arreglo, no null");
+        assertEquals(1, resultado[0], "El id retornado debe ser 1");
+        assertEquals("Amoxicilina", resultado[1], "El nombre retornado debe ser Amoxicilina");
+    }
+
+    // -------------------------------------------------------------------------
+    // TC-02: Búsqueda por nombre exacto válido
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("TC-02: Nombre exacto válido → retorna Object[]{id, nombre} correcto")
+    void tc02_nombreExactoValido_retornaProducto() {
+        Object[] resultado = dao.buscarProductoPorIdONombre("Paracetamol");
+
+        assertNotNull(resultado, "Con nombre='Paracetamol' existente debe retornar un arreglo, no null");
+        assertEquals("Paracetamol", resultado[1], "El nombre retornado debe ser Paracetamol");
+    }
+
+    // -------------------------------------------------------------------------
+    // TC-03: ID numérico inexistente → null
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("TC-03: ID numérico inexistente → retorna null")
+    void tc03_idNumericoInexistente_retornaNull() {
+        Object[] resultado = dao.buscarProductoPorIdONombre("9999");
+
+        assertNull(resultado, "Un id que no existe en la BD debe retornar null");
+    }
+
+    // -------------------------------------------------------------------------
+    // TC-04: Nombre inexistente → null
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("TC-04: Nombre inexistente → retorna null")
+    void tc04_nombreInexistente_retornaNull() {
+        Object[] resultado = dao.buscarProductoPorIdONombre("MedicamentoInexistente");
+
+        assertNull(resultado, "Un nombre que no existe en la BD debe retornar null");
+    }
+
+    // -------------------------------------------------------------------------
+    // TC-05: Nombre parcial → null (sin LIKE, sin coincidencia parcial)
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("TC-05: Nombre parcial ('Amox') → retorna null (búsqueda exacta, sin LIKE)")
+    void tc05_nombreParcial_retornaNull() {
+        Object[] resultado = dao.buscarProductoPorIdONombre("Amox");
+
+        assertNull(resultado,
+            "El método usa WHERE nombre = ?, por lo que 'Amox' no debe coincidir con 'Amoxicilina'");
+    }
+
+    // -------------------------------------------------------------------------
+    // TC-06: Cadena en blanco (solo espacios) → null
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("TC-06: Cadena en blanco → retorna null")
+    void tc06_cadenaEnBlanco_retornaNull() {
+        Object[] resultado = dao.buscarProductoPorIdONombre("   ");
+
+        assertNull(resultado, "Una cadena compuesta solo por espacios debe retornar null");
+    }
+
+    // -------------------------------------------------------------------------
+    // TC-07: Resultado contiene exactamente dos elementos {id, nombre}
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("TC-07: Resultado válido contiene exactamente 2 elementos: {id, nombre}")
+    void tc07_resultadoValido_tieneDosCampos() {
+        Object[] resultado = dao.buscarProductoPorIdONombre("Amoxicilina");
+
+        assertNotNull(resultado);
+        assertEquals(2, resultado.length, "El arreglo retornado debe tener exactamente 2 elementos");
+        assertInstanceOf(Integer.class, resultado[0], "El primer elemento debe ser Integer (id)");
+        assertInstanceOf(String.class,  resultado[1], "El segundo elemento debe ser String (nombre)");
+    }
+
+    // -------------------------------------------------------------------------
+    // TC-08: Número que es ID válido no cae en búsqueda por nombre
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("TC-08: Entrada '2' (ID de Paracetamol) resuelve correctamente via ruta ID")
+    void tc08_entradaNumerica_usaRutaId_noNombre() {
+        Object[] resultado = dao.buscarProductoPorIdONombre("2");
+
+        assertNotNull(resultado, "El id=2 existe y debe retornar resultado");
+        assertEquals(2, resultado[0]);
+        assertEquals("Paracetamol", resultado[1]);
+    }
+}

--- a/Refactorizacion-ALFA/src/test/java/model/InventarioDAORegresion.java
+++ b/Refactorizacion-ALFA/src/test/java/model/InventarioDAORegresion.java
@@ -1,0 +1,222 @@
+package model;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import org.junit.jupiter.api.AfterEach;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * PRU-002-03 — Pruebas de Regresión para operaciones pre-existentes del DAO (MR-002)
+ *
+ * Garantiza que las operaciones de inventario y ventas que existían antes del
+ * MR-002 no fueron afectadas por la introducción del método
+ * {@code buscarProductoPorIdONombre}. Usa SQLite en memoria para aislamiento.
+ *
+ * <p><b>Alcance de regresión cubierto:</b>
+ * <ul>
+ *   <li>CR-01 a CR-03: {@code registrarVenta} — flujo de éxito y persistencia en BD.</li>
+ *   <li>CR-04 a CR-05: {@code obtenerProductos} y {@code obtenerHistorialVentas}.</li>
+ *   <li>CR-06 a CR-07: {@code agregarProducto} y {@code eliminarProducto}.</li>
+ *   <li>CR-08:         {@code obtenerProductoIdPorNombre} — método previo al MR-002.</li>
+ * </ul>
+ *
+ * <p><b>Nota:</b> Los flujos de error de {@code registrarVenta} (nombre incorrecto,
+ * stock insuficiente) invocan {@code JOptionPane} y requieren entorno gráfico;
+ * se documentan en P9_Pruebas_MR-002.html como pruebas manuales.
+ */
+@DisplayName("PRU-002-03 | Regresión — Operaciones pre-existentes en InventarioDAO (MR-002)")
+class InventarioDAORegresionTest {
+
+    private Connection connection;
+    private InventarioDAO dao;
+
+    // -------------------------------------------------------------------------
+    // Ciclo de vida
+    // -------------------------------------------------------------------------
+
+    @BeforeEach
+    void setUp() throws SQLException {
+        connection = DriverManager.getConnection("jdbc:sqlite::memory:");
+        crearEsquema();
+        insertarProductoDePrueba();
+        dao = new InventarioDAO(connection);
+    }
+
+    @AfterEach
+    void tearDown() throws SQLException {
+        if (connection != null && !connection.isClosed()) {
+            connection.close();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private void crearEsquema() throws SQLException {
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute(
+                "CREATE TABLE IF NOT EXISTS productos (" +
+                "id INTEGER PRIMARY KEY AUTOINCREMENT, " +
+                "nombre TEXT, existencias INTEGER, lote TEXT, " +
+                "caducidad TEXT, fechaEntrada TEXT, fecha_separado TEXT)"
+            );
+            stmt.execute(
+                "CREATE TABLE IF NOT EXISTS historial_ventas (" +
+                "id INTEGER PRIMARY KEY AUTOINCREMENT, " +
+                "idProducto INTEGER, nombre TEXT, cantidad INTEGER, fechaVenta TEXT, " +
+                "FOREIGN KEY (idProducto) REFERENCES productos(id) ON DELETE CASCADE)"
+            );
+        }
+    }
+
+    private void insertarProductoDePrueba() throws SQLException {
+        try (PreparedStatement ps = connection.prepareStatement(
+                "INSERT INTO productos (nombre, existencias, lote, caducidad, fechaEntrada) VALUES (?, ?, ?, ?, ?)")) {
+            ps.setString(1, "Amoxicilina");
+            ps.setInt(2, 50);
+            ps.setString(3, "L001");
+            ps.setString(4, "2026-12");
+            ps.setString(5, "2025-01-01");
+            ps.executeUpdate();
+        }
+    }
+
+    private int contarFilas(String tabla) throws SQLException {
+        try (Statement stmt = connection.createStatement();
+             ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM " + tabla)) {
+            return rs.next() ? rs.getInt(1) : 0;
+        }
+    }
+
+    private int obtenerExistencias(int idProducto) throws SQLException {
+        try (PreparedStatement ps = connection.prepareStatement(
+                "SELECT existencias FROM productos WHERE id = ?")) {
+            ps.setInt(1, idProducto);
+            ResultSet rs = ps.executeQuery();
+            return rs.next() ? rs.getInt("existencias") : -1;
+        }
+    }
+
+    // =========================================================================
+    // CR-01 a CR-03: registrarVenta — flujo de éxito
+    // =========================================================================
+
+    @Test
+    @DisplayName("CR-01: registrarVenta(id, nombre, cantidad) retorna true en flujo de éxito")
+    void cr01_registrarVenta_retornaTrue() {
+        boolean resultado = dao.registrarVenta(1, "Amoxicilina", 5);
+
+        assertTrue(resultado, "registrarVenta debe retornar true cuando id, nombre y stock son válidos");
+    }
+
+    @Test
+    @DisplayName("CR-02: registrarVenta descuenta correctamente las existencias del producto")
+    void cr02_registrarVenta_decrementaExistencias() throws SQLException {
+        dao.registrarVenta(1, "Amoxicilina", 10);
+
+        assertEquals(40, obtenerExistencias(1),
+            "Las existencias deben reducirse en la cantidad vendida (50 - 10 = 40)");
+    }
+
+    @Test
+    @DisplayName("CR-03: registrarVenta inserta un registro en historial_ventas")
+    void cr03_registrarVenta_insertaEnHistorial() throws SQLException {
+        dao.registrarVenta(1, "Amoxicilina", 3);
+
+        assertEquals(1, contarFilas("historial_ventas"),
+            "Debe existir un registro en historial_ventas tras la venta");
+    }
+
+    // =========================================================================
+    // CR-04 a CR-05: obtenerProductos y obtenerHistorialVentas
+    // =========================================================================
+
+    @Test
+    @DisplayName("CR-04: obtenerProductos retorna la lista de productos sin errores")
+    void cr04_obtenerProductos_retornaDatos() {
+        Object[][] productos = dao.obtenerProductos();
+
+        assertNotNull(productos, "obtenerProductos no debe retornar null");
+        assertEquals(1, productos.length, "Debe haber exactamente 1 producto en la BD de prueba");
+    }
+
+    @Test
+    @DisplayName("CR-05: obtenerHistorialVentas retorna lista vacía cuando no hay ventas")
+    void cr05_obtenerHistorialVentas_listaVaciaInicial() {
+        var historial = dao.obtenerHistorialVentas();
+
+        assertNotNull(historial, "obtenerHistorialVentas no debe retornar null");
+        assertTrue(historial.isEmpty(), "Sin ventas registradas, la lista debe estar vacía");
+    }
+
+    // =========================================================================
+    // CR-06 a CR-07: agregarProducto y eliminarProducto
+    // =========================================================================
+
+    @Test
+    @DisplayName("CR-06: agregarProducto inserta correctamente un nuevo producto")
+    void cr06_agregarProducto_incrementaConteo() throws SQLException {
+        int antesDeAgregar = contarFilas("productos");
+
+        dao.agregarProducto("Ibuprofeno", "20", "L002", "2027-06");
+
+        assertEquals(antesDeAgregar + 1, contarFilas("productos"),
+            "agregarProducto debe insertar una nueva fila en la tabla productos");
+    }
+
+    @Test
+    @DisplayName("CR-07: eliminarProducto borra el registro y retorna true")
+    void cr07_eliminarProducto_eliminaRegistroYRetornaTrue() throws SQLException {
+        boolean resultado = dao.eliminarProducto(1);
+
+        assertTrue(resultado, "eliminarProducto debe retornar true cuando el id existe");
+        assertEquals(0, contarFilas("productos"),
+            "La tabla productos debe quedar vacía tras eliminar el único registro");
+    }
+
+    // =========================================================================
+    // CR-08: obtenerProductoIdPorNombre — método previo al MR-002
+    // =========================================================================
+
+    @Test
+    @DisplayName("CR-08: obtenerProductoIdPorNombre retorna el id correcto (método pre-MR-002)")
+    void cr08_obtenerProductoIdPorNombre_retornaIdCorrecto() {
+        int id = dao.obtenerProductoIdPorNombre("Amoxicilina");
+
+        assertEquals(1, id,
+            "obtenerProductoIdPorNombre debe seguir devolviendo el id correcto tras MR-002");
+    }
+
+    // =========================================================================
+    // CR-09: Coexistencia — buscarProductoPorIdONombre no interfiere con registrarVenta
+    // =========================================================================
+
+    @Test
+    @DisplayName("CR-09: buscarProductoPorIdONombre y registrarVenta coexisten sin interferencia")
+    void cr09_busquedaYRegistro_coexisten() throws SQLException {
+        // Primero buscar por nombre (nueva funcionalidad)
+        Object[] producto = dao.buscarProductoPorIdONombre("Amoxicilina");
+        assertNotNull(producto, "La búsqueda unificada debe encontrar el producto");
+
+        int id      = (int) producto[0];
+        String nombre = (String) producto[1];
+
+        // Luego registrar usando los datos obtenidos (flujo exacto de la vista)
+        boolean registrado = dao.registrarVenta(id, nombre, 5);
+        assertTrue(registrado, "La venta registrada con los datos de buscarProductoPorIdONombre debe tener éxito");
+
+        assertEquals(45, obtenerExistencias(1),
+            "Las existencias deben reducirse en 5 (50 - 5 = 45)");
+    }
+}


### PR DESCRIPTION
### Cambios
- Elimina txtId y txtNombre en RegistrarVentaView; los reemplaza con un único campo txtBusqueda ("ID o Nombre del Medicamento")
- Agrega buscarProductoPorIdONombre(String dato) en InventarioDAO: intenta parseo numérico → búsqueda por ID; si falla → búsqueda por nombre exacto (sin coincidencias parciales)
- Agrega método wrapper homónimo en InventarioController que delega al DAO
- Sin cambios en otras vistas ni en el esquema de la BD

### Pruebas
- 13 pruebas unitarias (PRU-002-01): todas pasaron ✓
- 8 pruebas de regresión automáticas (PRU-002-03): todas pasaron ✓
- Ver Plantillas 9 para casos funcionales y de regresión en la subcarpeta del MR en el canal de Teams (PRU-002-01 / PRU-002-02 / PRU-002-03)