### PR TITLE
fix: [Validación de fecha de caducidad antes de realizar una venta](#003)

### DIFF
--- a/Refactorizacion-ALFA/src/main/java/model/InventarioDAO.java
+++ b/Refactorizacion-ALFA/src/main/java/model/InventarioDAO.java
@@ -304,7 +304,7 @@ public class InventarioDAO {
                 YearMonth cadYM = YearMonth.parse(caducidad, DateTimeFormatter.ofPattern("yyyy-MM"));
                 LocalDate fechaExpiracion = cadYM.plusMonths(1).atDay(1);
                 if (!LocalDate.now().isBefore(fechaExpiracion)) {
-                    JOptionPane.showMessageDialog(null, "No se puede vender un producto caducado.", "Error", JOptionPane.ERROR_MESSAGE);
+                    JOptionPane.showMessageDialog(null, "No se puede registrar la venta: el medicamento está caducado", "Error", JOptionPane.ERROR_MESSAGE);
                     return false;
                 }
 

--- a/Refactorizacion-ALFA/src/main/java/model/InventarioDAO.java
+++ b/Refactorizacion-ALFA/src/main/java/model/InventarioDAO.java
@@ -250,12 +250,30 @@ public class InventarioDAO {
         return dataList.toArray(new Object[0][0]);
     }
 
+    /**
+     * Registra una venta descontando existencias del inventario y añadiendo
+     * un registro en {@code historial_ventas}.
+     *
+     * <p>Validaciones (en orden):
+     * <ol>
+     *   <li>El producto con {@code id} debe existir.</li>
+     *   <li>{@code nombreIngresado} debe coincidir (ignorando mayúsculas) con el nombre en BD.</li>
+     *   <li>Las existencias deben ser suficientes para cubrir {@code cantidadVendida}.</li>
+     *   <li>[MR-003 OPC-A] El producto no debe estar caducado. Un producto caduca al inicio
+     *       del mes siguiente al indicado en su campo {@code caducidad} (formato yyyy-MM).</li>
+     * </ol>
+     *
+     * @param id              ID del producto a vender.
+     * @param nombreIngresado Nombre del medicamento tal como lo ingresó el usuario.
+     * @param cantidadVendida Unidades a descontar del inventario.
+     * @return {@code true} si la venta se registró exitosamente; {@code false} en caso contrario.
+     */
     public boolean registrarVenta(int id, String nombreIngresado, int cantidadVendida) {
         try {
             ensureConnection();
 
             // Consulta el producto por su ID
-            String selectQuery = "SELECT nombre, existencias FROM productos WHERE id = ?";
+            String selectQuery = "SELECT nombre, existencias, caducidad FROM productos WHERE id = ?";
             try (PreparedStatement selectStmt = connection.prepareStatement(selectQuery)) {
                 selectStmt.setInt(1, id);
                 ResultSet rs = selectStmt.executeQuery();
@@ -268,6 +286,7 @@ public class InventarioDAO {
                 // Recupera el nombre real y el stock actual
                 String nombreReal = rs.getString("nombre");
                 int existenciasActuales = rs.getInt("existencias");
+                String caducidad = rs.getString("caducidad");
 
                 // Compara el nombre ingresado con el registrado
                 if (!nombreReal.equalsIgnoreCase(nombreIngresado)) {
@@ -277,6 +296,15 @@ public class InventarioDAO {
 
                 if (cantidadVendida > existenciasActuales) {
                     JOptionPane.showMessageDialog(null, "No hay suficientes existencias.", "Error", JOptionPane.ERROR_MESSAGE);
+                    return false;
+                }
+
+                // [MR-003 OPC-A] Validar que el producto no esté caducado.
+                // Un producto caduca al inicio del mes siguiente al indicado en caducidad.
+                YearMonth cadYM = YearMonth.parse(caducidad, DateTimeFormatter.ofPattern("yyyy-MM"));
+                LocalDate fechaExpiracion = cadYM.plusMonths(1).atDay(1);
+                if (!LocalDate.now().isBefore(fechaExpiracion)) {
+                    JOptionPane.showMessageDialog(null, "No se puede vender un producto caducado.", "Error", JOptionPane.ERROR_MESSAGE);
                     return false;
                 }
 

--- a/Refactorizacion-ALFA/src/main/java/model/InventarioDAO.java
+++ b/Refactorizacion-ALFA/src/main/java/model/InventarioDAO.java
@@ -563,6 +563,15 @@ public class InventarioDAO {
 
 
 
+    /**
+     * Retorna los productos cuya fecha de expiración ya ha pasado.
+     *
+     * <p>[MR-003 OPC-A] La fecha de expiración es el primer día del mes
+     * <em>siguiente</em> al indicado en {@code caducidad} (yyyy-MM). Un producto
+     * se considera caducado cuando {@code LocalDate.now() >= cadYM.plusMonths(1).atDay(1)}.
+     *
+     * @return Lista de arreglos {@code {id, nombre, existencias, lote, caducidad, fechaEntrada}}.
+     */
     public List<Object[]> obtenerMedicamentosCaducados() {
         List<Object[]> caducados = new ArrayList<>();
         try (Statement stmt = connection.createStatement();
@@ -574,9 +583,10 @@ public class InventarioDAO {
             while (rs.next()) {
                 String caducidadStr = rs.getString("caducidad"); // "yyyy-MM"
                 YearMonth cadYM = YearMonth.parse(caducidadStr, ymFormatter);
-                LocalDate primerDiaCaducidad = cadYM.atDay(1);
+                // [MR-003 OPC-A] Expira el primer día del mes siguiente al indicado.
+                LocalDate primerDiaCaducidad = cadYM.plusMonths(1).atDay(1);
 
-                if (primerDiaCaducidad.isBefore(hoy)) {
+                if (primerDiaCaducidad.isBefore(hoy) || primerDiaCaducidad.isEqual(hoy)) {
                     int id = rs.getInt("id");
                     String nombre = rs.getString("nombre");
                     int existencias = rs.getInt("existencias");

--- a/Refactorizacion-ALFA/src/main/java/model/InventarioDAO.java
+++ b/Refactorizacion-ALFA/src/main/java/model/InventarioDAO.java
@@ -517,6 +517,17 @@ public class InventarioDAO {
 
 
 
+    /**
+     * Retorna los productos cuya fecha de expiración está dentro de los próximos
+     * {@code diasUmbral} días.
+     *
+     * <p>[MR-003 OPC-A] La fecha de expiración es el primer día del mes
+     * <em>siguiente</em> al indicado en {@code caducidad} (yyyy-MM). Así, un producto
+     * con caducidad igual al mes actual aparece como próximo a caducar (no como caducado).
+     *
+     * @param diasUmbral Número máximo de días restantes para considerar un producto próximo.
+     * @return Lista de arreglos {@code {id, nombre, existencias, lote, caducidad, fechaEntrada}}.
+     */
     public List<Object[]> obtenerMedicamentosProximosACaducar(int diasUmbral) {
         List<Object[]> proximos = new ArrayList<>();
         try (Statement stmt = connection.createStatement();
@@ -530,8 +541,8 @@ public class InventarioDAO {
                 // Parseamos a YearMonth
                 YearMonth cadYM = YearMonth.parse(caducidadStr, ymFormatter);
 
-                // Tomamos el primer día de ese mes para calcular días restantes
-                LocalDate primerDiaCaducidad = cadYM.atDay(1);
+                // [MR-003 OPC-A] Expira el primer día del mes siguiente al indicado.
+                LocalDate primerDiaCaducidad = cadYM.plusMonths(1).atDay(1);
                 long diasRestantes = ChronoUnit.DAYS.between(hoy, primerDiaCaducidad);
 
                 if (diasRestantes >= 0 && diasRestantes <= diasUmbral) {

--- a/Refactorizacion-ALFA/src/main/java/view/InventarioView.java
+++ b/Refactorizacion-ALFA/src/main/java/view/InventarioView.java
@@ -404,7 +404,8 @@ public class InventarioView {
                     DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM");
                     // Convertir a YearMonth
                     YearMonth cadYM = YearMonth.parse(value.toString(), formatter);
-                    LocalDate primerDiaCaducidad = cadYM.atDay(1);
+                    // [MR-003 OPC-A] Expira el primer día del mes siguiente al indicado.
+                    LocalDate primerDiaCaducidad = cadYM.plusMonths(1).atDay(1);
                     LocalDate hoy = LocalDate.now();
                     long diasRestantes = ChronoUnit.DAYS.between(hoy, primerDiaCaducidad);
 

--- a/Refactorizacion-ALFA/src/test/java/model/InventarioDAOCaducidadTest.java
+++ b/Refactorizacion-ALFA/src/test/java/model/InventarioDAOCaducidadTest.java
@@ -1,0 +1,215 @@
+package model;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+
+import org.junit.jupiter.api.AfterEach;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * PRU-003-01 — Pruebas Unitarias: validación de caducidad en registrarVenta
+ * y regla de expiración en obtenerMedicamentosProximosACaducar /
+ * obtenerMedicamentosCaducados (MR-003 OPC-A).
+ *
+ * <p>Usa SQLite en memoria para aislamiento total. No hay JOptionPane en los
+ * flujos de éxito; los flujos de error que llaman a JOptionPane se documentan
+ * como pruebas manuales en P9_Pruebas-Funcionales_MR-003.html.
+ */
+@DisplayName("PRU-003-01 | InventarioDAO — validación de caducidad (MR-003)")
+class InventarioDAOCaducidadTest {
+
+    private Connection connection;
+    private InventarioDAO dao;
+
+    private static final DateTimeFormatter FMT = DateTimeFormatter.ofPattern("yyyy-MM");
+
+    // -------------------------------------------------------------------------
+    // Ciclo de vida
+    // -------------------------------------------------------------------------
+
+    @BeforeEach
+    void setUp() throws SQLException {
+        connection = DriverManager.getConnection("jdbc:sqlite::memory:");
+        crearEsquema();
+        dao = new InventarioDAO(connection);
+    }
+
+    @AfterEach
+    void tearDown() throws SQLException {
+        if (connection != null && !connection.isClosed()) connection.close();
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private void crearEsquema() throws SQLException {
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute(
+                "CREATE TABLE IF NOT EXISTS productos (" +
+                "id INTEGER PRIMARY KEY AUTOINCREMENT, nombre TEXT, " +
+                "existencias INTEGER, lote TEXT, caducidad TEXT, " +
+                "fechaEntrada TEXT, fecha_separado TEXT)"
+            );
+            stmt.execute(
+                "CREATE TABLE IF NOT EXISTS historial_ventas (" +
+                "id INTEGER PRIMARY KEY AUTOINCREMENT, idProducto INTEGER, " +
+                "nombre TEXT, cantidad INTEGER, fechaVenta TEXT, " +
+                "FOREIGN KEY (idProducto) REFERENCES productos(id) ON DELETE CASCADE)"
+            );
+        }
+    }
+
+    private int insertarProducto(String nombre, int existencias, String caducidad) throws SQLException {
+        String sql = "INSERT INTO productos (nombre, existencias, lote, caducidad, fechaEntrada) VALUES (?, ?, ?, ?, ?)";
+        try (PreparedStatement ps = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+            ps.setString(1, nombre);
+            ps.setInt(2, existencias);
+            ps.setString(3, "L-TEST");
+            ps.setString(4, caducidad);
+            ps.setString(5, "2025-01-01");
+            ps.executeUpdate();
+            ResultSet keys = ps.getGeneratedKeys();
+            return keys.next() ? keys.getInt(1) : -1;
+        }
+    }
+
+    /** Caducidad que ya expiró (mes de hace 2 meses → expiryDate = hace 1 mes). */
+    private String caducidadExpirada() {
+        return YearMonth.now().minusMonths(2).format(FMT);
+    }
+
+    /** Caducidad que expira este mes → expiryDate = primer día del mes que viene (futuro). */
+    private String caducidadMesActual() {
+        return YearMonth.now().format(FMT);
+    }
+
+    /** Caducidad que expira en 3 meses → expiryDate muy en el futuro. */
+    private String caducidadFutura() {
+        return YearMonth.now().plusMonths(3).format(FMT);
+    }
+
+    // =========================================================================
+    // TC-01 a TC-03: registrarVenta — validación de caducidad
+    // =========================================================================
+
+    @Test
+    @DisplayName("TC-01: Producto vigente → registrarVenta retorna true")
+    void tc01_productoVigente_registrarVentaRetornaTrue() throws SQLException {
+        int id = insertarProducto("Amoxicilina", 50, caducidadFutura());
+
+        boolean resultado = dao.registrarVenta(id, "Amoxicilina", 5);
+
+        assertTrue(resultado, "Producto con caducidad futura debe registrar venta sin problemas");
+    }
+
+    @Test
+    @DisplayName("TC-02: Producto con caducidad = mes actual → aún vigente, venta permitida")
+    void tc02_caducidadMesActual_ventaPermitida() throws SQLException {
+        int id = insertarProducto("Paracetamol", 30, caducidadMesActual());
+
+        boolean resultado = dao.registrarVenta(id, "Paracetamol", 1);
+
+        assertTrue(resultado,
+            "Un producto cuyo mes de caducidad es el actual no ha expirado aún; la venta debe permitirse");
+    }
+
+    @Test
+    @DisplayName("TC-03: Producto caducado (mes ya pasó) → registrarVenta retorna false sin vender")
+    void tc03_productoCaducado_registrarVentaRetornaFalse() throws SQLException {
+        int id = insertarProducto("Ibuprofeno", 20, caducidadExpirada());
+
+        // En entorno headless el JOptionPane lanza HeadlessException antes del return false.
+        // Validamos que la venta no se registra comprobando historial_ventas.
+        try {
+            dao.registrarVenta(id, "Ibuprofeno", 1);
+        } catch (Exception ignored) {
+            // HeadlessException esperada; lo relevante es que no haya registro
+        }
+
+        try (Statement stmt = connection.createStatement();
+             ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM historial_ventas")) {
+            assertTrue(rs.next());
+            assertEquals(0, rs.getInt(1), "No debe existir ningún registro en historial_ventas para producto caducado");
+        }
+    }
+
+    @Test
+    @DisplayName("TC-04: Producto vigente → existencias se decrementan tras la venta")
+    void tc04_productoVigente_existenciasDecrementan() throws SQLException {
+        int id = insertarProducto("Vitamina C", 100, caducidadFutura());
+
+        dao.registrarVenta(id, "Vitamina C", 10);
+
+        try (PreparedStatement ps = connection.prepareStatement(
+                "SELECT existencias FROM productos WHERE id = ?")) {
+            ps.setInt(1, id);
+            ResultSet rs = ps.executeQuery();
+            assertTrue(rs.next());
+            assertEquals(90, rs.getInt("existencias"), "Existencias deben reducirse en la cantidad vendida");
+        }
+    }
+
+    // =========================================================================
+    // TC-05 a TC-08: obtenerMedicamentosProximosACaducar — nueva regla
+    // =========================================================================
+
+    @Test
+    @DisplayName("TC-05: Producto con caducidad = mes actual → aparece en próximos a caducar")
+    void tc05_caducidadMesActual_apareceEnProximos() throws SQLException {
+        insertarProducto("Med-A", 10, caducidadMesActual());
+
+        var proximos = dao.obtenerMedicamentosProximosACaducar(31);
+
+        assertFalse(proximos.isEmpty(),
+            "Producto con caducidad = mes actual debe aparecer en próximos a caducar");
+    }
+
+    @Test
+    @DisplayName("TC-06: Producto caducado (mes ya pasó) → NO aparece en próximos a caducar")
+    void tc06_caducidadExpirada_noApareceEnProximos() throws SQLException {
+        insertarProducto("Med-B", 10, caducidadExpirada());
+
+        var proximos = dao.obtenerMedicamentosProximosACaducar(31);
+
+        assertTrue(proximos.isEmpty(),
+            "Producto caducado no debe aparecer en próximos a caducar");
+    }
+
+    // =========================================================================
+    // TC-07 a TC-08: obtenerMedicamentosCaducados — nueva regla
+    // =========================================================================
+
+    @Test
+    @DisplayName("TC-07: Producto con caducidad = mes actual → NO aparece en caducados")
+    void tc07_caducidadMesActual_noApareceEnCaducados() throws SQLException {
+        insertarProducto("Med-C", 10, caducidadMesActual());
+
+        var caducados = dao.obtenerMedicamentosCaducados();
+
+        assertTrue(caducados.isEmpty(),
+            "Producto cuyo mes de caducidad es el actual no debe aparecer como caducado");
+    }
+
+    @Test
+    @DisplayName("TC-08: Producto caducado (mes ya pasó) → aparece en caducados")
+    void tc08_caducidadExpirada_apareceEnCaducados() throws SQLException {
+        insertarProducto("Med-D", 10, caducidadExpirada());
+
+        var caducados = dao.obtenerMedicamentosCaducados();
+
+        assertFalse(caducados.isEmpty(),
+            "Producto cuyo mes de caducidad ya pasó debe aparecer en la lista de caducados");
+    }
+}

--- a/Refactorizacion-ALFA/src/test/java/view/HoverTableCellRendererTest.java
+++ b/Refactorizacion-ALFA/src/test/java/view/HoverTableCellRendererTest.java
@@ -62,21 +62,21 @@ class HoverTableCellRendererTest {
     }
 
     /**
-     * Devuelve una fecha "yyyy-MM" cuyo primer día está entre 1 y 30 días
-     * en el futuro (producto próximo a caducar).
-     * Busca en los próximos 3 meses para cubrir bordes de mes.
+     * Devuelve una fecha "yyyy-MM" cuyo primer día del mes SIGUIENTE está entre 1 y 30 días
+     * en el futuro (producto próximo a caducar según regla MR-003: expira en plusMonths(1).atDay(1)).
+     * Busca en un rango de -1 a +3 meses para cubrir bordes de mes.
      */
     private String fechaProximaCaducidad() {
         LocalDate hoy = LocalDate.now();
-        for (int i = 0; i <= 3; i++) {
+        for (int i = -1; i <= 3; i++) {
             YearMonth ym = YearMonth.now().plusMonths(i);
-            long dias = ChronoUnit.DAYS.between(hoy, ym.atDay(1));
+            long dias = ChronoUnit.DAYS.between(hoy, ym.plusMonths(1).atDay(1));
             if (dias >= 1 && dias <= 30) {
                 return ym.format(DateTimeFormatter.ofPattern("yyyy-MM"));
             }
         }
-        // Fallback: si no encuentra ninguno, usa el mes siguiente de todos modos
-        return YearMonth.now().plusMonths(1).format(DateTimeFormatter.ofPattern("yyyy-MM"));
+        // Fallback: mes actual (su expiryDate = primer día del mes siguiente)
+        return YearMonth.now().format(DateTimeFormatter.ofPattern("yyyy-MM"));
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Cambios

- Agrega validación de caducidad en `InventarioDAO.registrarVenta`: calcula
  `fechaExpiracion = cadYM.plusMonths(1).atDay(1)`; aborta con mensaje de error
  si `LocalDate.now() >= fechaExpiracion`
- Corrige regla de color en `HoverTableCellRenderer` (InventarioView línea 371):
  `cadYM.atDay(1)` → `cadYM.plusMonths(1).atDay(1)`; productos del mes actual
  ahora muestran rojo claro (próximo) en vez de rojo fuerte (caducado)
- Aplica misma regla de expiración a `obtenerMedicamentosProximosACaducar` y
  `obtenerMedicamentosCaducados` en InventarioDAO
- Sin cambios en esquema de BD, otras vistas ni flujos no relacionados

## Pruebas

- 8 pruebas unitarias automáticas (PRU-003-01 — `InventarioDAOCaducidadTest`): todas pasaron ✓
- 6 pruebas funcionales manuales (PRU-003-02): todas pasaron ✓
- 9 pruebas de regresión (PRU-003-03): todas pasaron ✓
- Ver Plantillas 9 para detalle de casos en la subcarpeta del MR en el canal de Teams
  (PRU-003-01 / PRU-003-02 / PRU-003-03)