### PR TITLE
fix: [Validación de caducidad y existencias antes de registrar un apartado](#004)

### DIFF
--- a/Refactorizacion-ALFA/src/main/java/model/InventarioDAO.java
+++ b/Refactorizacion-ALFA/src/main/java/model/InventarioDAO.java
@@ -602,14 +602,56 @@ public class InventarioDAO {
     }
 
 
+    /**
+     * Determina si un medicamento está caducado.
+     * Un medicamento se considera caducado únicamente cuando su mes de caducidad ya pasó
+     * (es decir, el mes y año actuales son posteriores al mes de caducidad registrado).
+     *
+     * @param cad mes de caducidad del medicamento en formato YearMonth
+     * @return {@code true} si el mes actual es posterior al mes de caducidad; {@code false} en caso contrario
+     */
+    private boolean estaCaducado(YearMonth cad) {
+        return YearMonth.now().isAfter(cad);
+    }
 
-
-
+    /**
+     * Registra el apartado de un producto en la base de datos.
+     * Antes de ejecutar el UPDATE, valida que el producto no esté caducado y que tenga
+     * existencias disponibles. Si alguna validación falla, muestra un mensaje de error
+     * mediante JOptionPane y retorna {@code false} sin modificar la base de datos.
+     *
+     * @param id           identificador del producto a apartar
+     * @param fechaSeparado fecha en que se registra el apartado (formato "yyyy-MM-dd")
+     * @return {@code true} si el apartado se registró correctamente; {@code false} si el producto
+     *         está caducado, no tiene existencias, no existe o ocurre un error de base de datos
+     */
     public boolean separarProducto(int id, String fechaSeparado) {
         try {
             ensureConnection();
-            String sql = "UPDATE productos SET fecha_separado = ? WHERE id = ?";
-            try (PreparedStatement pstmt = connection.prepareStatement(sql)) {
+            String selectSql = "SELECT nombre, caducidad, existencias FROM productos WHERE id = ?";
+            try (PreparedStatement selectStmt = connection.prepareStatement(selectSql)) {
+                selectStmt.setInt(1, id);
+                try (ResultSet rs = selectStmt.executeQuery()) {
+                    if (!rs.next()) return false;
+                    String caducidadStr = rs.getString("caducidad");
+                    int existencias = rs.getInt("existencias");
+                    YearMonth caducidad = YearMonth.parse(caducidadStr, DateTimeFormatter.ofPattern("yyyy-MM"));
+                    if (estaCaducado(caducidad)) {
+                        JOptionPane.showMessageDialog(null,
+                            "No se puede registrar el apartado: el medicamento está caducado",
+                            "Error", JOptionPane.ERROR_MESSAGE);
+                        return false;
+                    }
+                    if (existencias <= 0) {
+                        JOptionPane.showMessageDialog(null,
+                            "No se puede registrar el apartado: el medicamento no tiene existencias disponibles",
+                            "Error", JOptionPane.ERROR_MESSAGE);
+                        return false;
+                    }
+                }
+            }
+            String updateSql = "UPDATE productos SET fecha_separado = ? WHERE id = ?";
+            try (PreparedStatement pstmt = connection.prepareStatement(updateSql)) {
                 pstmt.setString(1, fechaSeparado);
                 pstmt.setInt(2, id);
                 int filasAfectadas = pstmt.executeUpdate();

--- a/Refactorizacion-ALFA/src/main/java/view/ApartadosView.java
+++ b/Refactorizacion-ALFA/src/main/java/view/ApartadosView.java
@@ -1,16 +1,36 @@
 package view;
 
-import controller.InventarioController;
-import javax.swing.*;
-import javax.swing.table.*;
-import java.awt.*;
-import java.awt.event.*;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Cursor;
+import java.awt.FlowLayout;
+import java.awt.Font;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseMotionAdapter;
 import java.io.File;
 import java.time.LocalDate;
 import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+
+import javax.swing.BorderFactory;
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JFileChooser;
+import javax.swing.JFrame;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.ListSelectionModel;
+import javax.swing.table.DefaultTableCellRenderer;
+import javax.swing.table.DefaultTableModel;
+import javax.swing.table.TableRowSorter;
+
+import controller.InventarioController;
 
 public class ApartadosView extends JDialog {
     private InventarioController controller;
@@ -301,14 +321,14 @@ public class ApartadosView extends JDialog {
                     DateTimeFormatter ymFormatter = DateTimeFormatter.ofPattern("yyyy-MM");
                     YearMonth cadYM = YearMonth.parse(value.toString(), ymFormatter);
 
-                    // Tomamos el primer día de ese mes
-                    LocalDate primerDiaCaducidad = cadYM.atDay(1);
+                    YearMonth hoyYM = YearMonth.now();
                     LocalDate hoy = LocalDate.now();
-                    long diasRestantes = ChronoUnit.DAYS.between(hoy, primerDiaCaducidad);
+                    LocalDate expiryDate = cadYM.plusMonths(1).atDay(1);
+                    long diasHastaExpiry = ChronoUnit.DAYS.between(hoy, expiryDate);
 
-                    if (diasRestantes < 0) {
+                    if (hoyYM.isAfter(cadYM)) {
                         c.setBackground(new Color(255, 0, 0)); // Rojo fuerte (ya caducado)
-                    } else if (diasRestantes <= 30) {
+                    } else if (diasHastaExpiry <= 30) {
                         c.setBackground(new Color(255, 153, 153)); // Rojo claro (próximo a caducar)
                     } else if (row == hoveredRow && !isSelected) {
                         c.setBackground(new Color(220, 240, 255)); // Hover

--- a/Refactorizacion-ALFA/src/test/java/model/InventarioDAOSepararProductoTest.java
+++ b/Refactorizacion-ALFA/src/test/java/model/InventarioDAOSepararProductoTest.java
@@ -1,0 +1,186 @@
+package model;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+
+import org.junit.jupiter.api.AfterEach;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * PRU-004-01 — Pruebas Unitarias: validación de caducidad y existencias en
+ * separarProducto y método auxiliar estaCaducado (MR-004).
+ *
+ * <p>Usa SQLite en memoria para aislamiento total. Los flujos que invocan
+ * JOptionPane en entorno headless lanzan HeadlessException; en esos casos
+ * la prueba valida el estado de la BD en lugar del valor de retorno.
+ */
+@DisplayName("PRU-004-01 | InventarioDAO — validación en separarProducto (MR-004)")
+class InventarioDAOSepararProductoTest {
+
+    private Connection connection;
+    private InventarioDAO dao;
+
+    private static final DateTimeFormatter FMT = DateTimeFormatter.ofPattern("yyyy-MM");
+
+    // -------------------------------------------------------------------------
+    // Ciclo de vida
+    // -------------------------------------------------------------------------
+
+    @BeforeEach
+    void setUp() throws SQLException {
+        connection = DriverManager.getConnection("jdbc:sqlite::memory:");
+        crearEsquema();
+        dao = new InventarioDAO(connection);
+    }
+
+    @AfterEach
+    void tearDown() throws SQLException {
+        if (connection != null && !connection.isClosed()) connection.close();
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private void crearEsquema() throws SQLException {
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute(
+                "CREATE TABLE IF NOT EXISTS productos (" +
+                "id INTEGER PRIMARY KEY AUTOINCREMENT, nombre TEXT, " +
+                "existencias INTEGER, lote TEXT, caducidad TEXT, " +
+                "fechaEntrada TEXT, fecha_separado TEXT)"
+            );
+        }
+    }
+
+    private int insertarProducto(String nombre, int existencias, String caducidad) throws SQLException {
+        String sql = "INSERT INTO productos (nombre, existencias, lote, caducidad, fechaEntrada) VALUES (?, ?, ?, ?, ?)";
+        try (PreparedStatement ps = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+            ps.setString(1, nombre);
+            ps.setInt(2, existencias);
+            ps.setString(3, "L-TEST");
+            ps.setString(4, caducidad);
+            ps.setString(5, "2025-01-01");
+            ps.executeUpdate();
+            ResultSet keys = ps.getGeneratedKeys();
+            return keys.next() ? keys.getInt(1) : -1;
+        }
+    }
+
+    private String fechaSeparadoEnBD(int id) throws SQLException {
+        try (PreparedStatement ps = connection.prepareStatement(
+                "SELECT fecha_separado FROM productos WHERE id = ?")) {
+            ps.setInt(1, id);
+            ResultSet rs = ps.executeQuery();
+            return rs.next() ? rs.getString("fecha_separado") : null;
+        }
+    }
+
+    /** Caducidad que ya expiró (mes de hace 2 meses). */
+    private String caducidadExpirada() {
+        return YearMonth.now().minusMonths(2).format(FMT);
+    }
+
+    /** Caducidad = mes actual → producto aún vigente hasta que el mes pase. */
+    private String caducidadMesActual() {
+        return YearMonth.now().format(FMT);
+    }
+
+    /** Caducidad en 3 meses → producto claramente vigente. */
+    private String caducidadFutura() {
+        return YearMonth.now().plusMonths(3).format(FMT);
+    }
+
+    // =========================================================================
+    // TC-01: Producto vigente + existencias > 0 → retorna true y registra apartado
+    // =========================================================================
+
+    @Test
+    @DisplayName("TC-01: Producto vigente con existencias → separarProducto retorna true y registra fecha_separado")
+    void tc01_productoVigente_conExistencias_retornaTrueYRegistra() throws SQLException {
+        int id = insertarProducto("Amoxicilina", 10, caducidadFutura());
+
+        boolean resultado = dao.separarProducto(id, "2026-05-18");
+
+        assertTrue(resultado, "Producto vigente con existencias debe poder apartarse");
+        assertEquals("2026-05-18", fechaSeparadoEnBD(id),
+            "fecha_separado debe quedar registrada en la BD tras el apartado exitoso");
+    }
+
+    // =========================================================================
+    // TC-02: Producto caducado (mes ya pasó) → sin apartado en BD
+    // =========================================================================
+
+    @Test
+    @DisplayName("TC-02: Producto caducado (mes ya pasó) → separarProducto no registra apartado")
+    void tc02_productoCaducado_noRegistraApartado() throws SQLException {
+        int id = insertarProducto("Ibuprofeno", 5, caducidadExpirada());
+
+        try {
+            dao.separarProducto(id, "2026-05-18");
+        } catch (Exception ignored) {
+            // HeadlessException esperada en entorno sin GUI; lo relevante es el estado de la BD
+        }
+
+        assertNull(fechaSeparadoEnBD(id),
+            "Producto caducado no debe tener fecha_separado registrada");
+    }
+
+    // =========================================================================
+    // TC-03: Caducidad = mes actual → vigente, apartado permitido
+    // =========================================================================
+
+    @Test
+    @DisplayName("TC-03: Caducidad = mes actual → producto aún vigente, separarProducto retorna true")
+    void tc03_caducidadMesActual_productoVigente_retornaTrue() throws SQLException {
+        int id = insertarProducto("Paracetamol", 20, caducidadMesActual());
+
+        boolean resultado = dao.separarProducto(id, "2026-05-18");
+
+        assertTrue(resultado,
+            "Producto con caducidad en el mes actual no ha expirado; el apartado debe permitirse");
+    }
+
+    // =========================================================================
+    // TC-04: Producto sin existencias (existencias = 0) → sin apartado en BD
+    // =========================================================================
+
+    @Test
+    @DisplayName("TC-04: Producto sin existencias → separarProducto no registra apartado")
+    void tc04_productoSinExistencias_noRegistraApartado() throws SQLException {
+        int id = insertarProducto("Vitamina C", 0, caducidadFutura());
+
+        try {
+            dao.separarProducto(id, "2026-05-18");
+        } catch (Exception ignored) {
+            // HeadlessException esperada en entorno sin GUI
+        }
+
+        assertNull(fechaSeparadoEnBD(id),
+            "Producto sin existencias no debe tener fecha_separado registrada");
+    }
+
+    // =========================================================================
+    // TC-05: ID de producto inexistente → retorna false
+    // =========================================================================
+
+    @Test
+    @DisplayName("TC-05: ID de producto inexistente → separarProducto retorna false")
+    void tc05_productoInexistente_retornaFalse() throws SQLException {
+        boolean resultado = dao.separarProducto(9999, "2026-05-18");
+
+        assertFalse(resultado, "ID inexistente debe retornar false");
+    }
+}


### PR DESCRIPTION
## Cambios

- Agrega validación en InventarioDAO.separarProducto: consulta caducidad y
  existencias antes del UPDATE; nuevo método privado estaCaducado(YearMonth cad)
  retorna YearMonth.now().isAfter(cad); aborta con JOptionPane de error si
  el medicamento está caducado o existencias <= 0; retorna false si ID no existe
- Corrige regla de color en HoverTableCellRenderer (ApartadosView): cambia
  anclaje de expiración de cadYM.atDay(1) → comparación directa YearMonth
  (isAfter) para "rojo fuerte" y cadYM.plusMonths(1).atDay(1) para "próximo
  a caducar"; productos del mes actual ahora muestran rojo claro (próximo)
  en vez de rojo fuerte (caducado); alinea con regla ya aplicada en MR-003
- Sin cambios en esquema de BD, otras vistas ni flujos no relacionados

## Pruebas

- 5 pruebas unitarias automáticas (PRU-004-01 — InventarioDAOSepararProductoTest):
  todas pasaron ✓
- 7 pruebas funcionales manuales (PRU-004-02): todas pasaron ✓
- 11 pruebas de regresión (PRU-004-03, incluye mvn test 42/42 PASS): todas pasaron ✓
- Ver Plantillas 9 para detalle de casos en la subcarpeta del MR en el canal de Teams
  (PRU-004-01 / PRU-004-02 / PRU-004-03)