### PR TITLE
feat: [Look & Feel moderno con FlatLaf y alternancia de tema claro/oscuro](#006)

### DIFF
--- a/Refactorizacion-ALFA/config.properties
+++ b/Refactorizacion-ALFA/config.properties
@@ -1,0 +1,2 @@
+# [MR-006 – OPC-A] Preferencia de tema visual: light | dark
+theme=light

--- a/Refactorizacion-ALFA/pom.xml
+++ b/Refactorizacion-ALFA/pom.xml
@@ -36,6 +36,13 @@
             <artifactId>jcalendar</artifactId>
             <version>1.4</version>
         </dependency>
+
+        <!-- [MR-006 – OPC-A] FlatLaf: Look & Feel moderno con soporte dark/light -->
+        <dependency>
+            <groupId>com.formdev</groupId>
+            <artifactId>flatlaf</artifactId>
+            <version>3.4.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/Refactorizacion-ALFA/src/main/java/InventarioApp.java
+++ b/Refactorizacion-ALFA/src/main/java/InventarioApp.java
@@ -1,16 +1,82 @@
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Properties;
+
 import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+
+import com.formdev.flatlaf.FlatDarkLaf;
+import com.formdev.flatlaf.FlatLightLaf;
+
 import controller.InventarioController;
 import model.InventarioDAO;
 import view.InventarioView;
 
+/**
+ * Punto de entrada de ALFA-INVENTORY.
+ *
+ * <p>[MR-006 – OPC-A] Lee la preferencia de tema desde {@code config.properties}
+ * y aplica FlatDarkLaf o FlatLightLaf antes de construir la UI. La preferencia
+ * se actualiza en tiempo de ejecución desde {@link view.InventarioView}.
+ */
 public class InventarioApp {
+
+    /**
+     * [MR-006 – OPC-A] Ruta del archivo de configuración de preferencias de usuario.
+     * Se ubica junto al JAR ejecutable (directorio de trabajo).
+     */
+    public static final String CONFIG_PATH = "config.properties";
+
+    /**
+     * [MR-006 – OPC-A] Lee la preferencia de tema y aplica el Look &amp; Feel
+     * correspondiente antes de lanzar la interfaz gráfica.
+     *
+     * @param args Argumentos de línea de comandos (no utilizados).
+     */
     public static void main(String[] args) {
+        aplicarTema(leerTema());
         SwingUtilities.invokeLater(() -> {
             InventarioDAO dao = new InventarioDAO();
-            dao.crearBaseDeDatos(); // Crea las tablas si no existen
+            dao.crearBaseDeDatos();
             InventarioController controller = new InventarioController(dao);
             new InventarioView(controller);
         });
     }
-}
 
+    /**
+     * [MR-006 – OPC-A] Lee el valor {@code theme} de {@code config.properties}.
+     * Si el archivo no existe o la lectura falla, retorna {@code "light"} por defecto.
+     *
+     * @return {@code "dark"} o {@code "light"}.
+     */
+    public static String leerTema() {
+        Properties props = new Properties();
+        File cfg = new File(CONFIG_PATH);
+        if (cfg.exists()) {
+            try (FileInputStream fis = new FileInputStream(cfg)) {
+                props.load(fis);
+            } catch (IOException ignored) { }
+        }
+        return props.getProperty("theme", "light");
+    }
+
+    /**
+     * [MR-006 – OPC-A] Aplica {@link FlatDarkLaf} si {@code tema} es {@code "dark"},
+     * {@link FlatLightLaf} en cualquier otro caso. Los errores se imprimen en stderr
+     * sin interrumpir el arranque.
+     *
+     * @param tema Cadena leída desde {@code config.properties}.
+     */
+    public static void aplicarTema(String tema) {
+        try {
+            if ("dark".equalsIgnoreCase(tema)) {
+                UIManager.setLookAndFeel(new FlatDarkLaf());
+            } else {
+                UIManager.setLookAndFeel(new FlatLightLaf());
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/Refactorizacion-ALFA/src/main/java/view/InventarioView.java
+++ b/Refactorizacion-ALFA/src/main/java/view/InventarioView.java
@@ -12,12 +12,15 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseMotionAdapter;
 import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.time.LocalDate;
 import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.Properties;
 
 import javax.swing.BorderFactory;
 import javax.swing.JButton;
@@ -33,9 +36,13 @@ import javax.swing.JToggleButton;
 import javax.swing.ListSelectionModel;
 import javax.swing.RowFilter;
 import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.DefaultTableModel;
 import javax.swing.table.TableRowSorter;
+
+import com.formdev.flatlaf.FlatDarkLaf;
+import com.formdev.flatlaf.FlatLightLaf;
 
 import controller.InventarioController;
 
@@ -152,6 +159,35 @@ public class InventarioView {
             table.repaint();
         });
         rightPanel.add(btnToggleColores);
+
+        // [MR-006 – OPC-A] Botón para alternar entre tema claro y oscuro (FlatLaf)
+        String temaInicial = leerTema();
+        JToggleButton btnTema = new JToggleButton(
+                "dark".equalsIgnoreCase(temaInicial) ? "Tema: Oscuro" : "Tema: Claro");
+        btnTema.setSelected("dark".equalsIgnoreCase(temaInicial));
+        btnTema.setFont(new Font("Arial", Font.BOLD, 14));
+        btnTema.setFocusPainted(false);
+        btnTema.setBackground(new Color(30, 136, 229));
+        btnTema.setForeground(Color.WHITE);
+        btnTema.setBorder(BorderFactory.createEmptyBorder(10, 15, 10, 15));
+        btnTema.addActionListener(e -> {
+            String nuevoTema = btnTema.isSelected() ? "dark" : "light";
+            btnTema.setText(btnTema.isSelected() ? "Tema: Oscuro" : "Tema: Claro");
+            try {
+                if (btnTema.isSelected()) {
+                    UIManager.setLookAndFeel(new FlatDarkLaf());
+                } else {
+                    UIManager.setLookAndFeel(new FlatLightLaf());
+                }
+                SwingUtilities.updateComponentTreeUI(frame);
+                frame.pack();
+            } catch (Exception ex) {
+                ex.printStackTrace();
+            }
+            guardarTema(nuevoTema);
+        });
+        rightPanel.add(btnTema);
+
         JButton btnRefrescar = createButton("Refrescar", "");
         addHoverEffect(btnRefrescar);
         rightPanel.add(btnRefrescar);
@@ -364,6 +400,40 @@ public class InventarioView {
 
     public JFrame getFrame() {
         return frame;
+    }
+
+    /**
+     * [MR-006 – OPC-A] Lee el valor {@code theme} de {@code config.properties}
+     * ubicado en el directorio de trabajo. Retorna {@code "light"} si el archivo
+     * no existe o la clave no está definida.
+     *
+     * @return {@code "dark"} o {@code "light"}.
+     */
+    private String leerTema() {
+        Properties props = new Properties();
+        File cfg = new File("config.properties");
+        if (cfg.exists()) {
+            try (java.io.FileInputStream fis = new java.io.FileInputStream(cfg)) {
+                props.load(fis);
+            } catch (IOException ignored) { }
+        }
+        return props.getProperty("theme", "light");
+    }
+
+    /**
+     * [MR-006 – OPC-A] Persiste la preferencia de tema en {@code config.properties}
+     * en el directorio de trabajo para que el arranque siguiente aplique el mismo tema.
+     *
+     * @param tema {@code "light"} o {@code "dark"}.
+     */
+    private void guardarTema(String tema) {
+        Properties props = new Properties();
+        props.setProperty("theme", tema);
+        try (FileOutputStream fos = new FileOutputStream("config.properties")) {
+            props.store(fos, "MR-006 – OPC-A: preferencia de tema visual");
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
     }
 
     /**

--- a/Refactorizacion-ALFA/src/test/java/InventarioAppTemaTest.java
+++ b/Refactorizacion-ALFA/src/test/java/InventarioAppTemaTest.java
@@ -1,0 +1,138 @@
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Properties;
+
+import org.junit.jupiter.api.AfterEach;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * PRU-006-01 — Pruebas Unitarias: leerTema y aplicarTema en InventarioApp (MR-006).
+ *
+ * <p>Verifica que {@link InventarioApp#leerTema()} retorne el valor correcto
+ * leyendo {@code config.properties} del directorio de trabajo, y que
+ * {@link InventarioApp#aplicarTema(String)} no lance excepción para los
+ * valores válidos {@code "light"} y {@code "dark"}.
+ *
+ * <p>Cada prueba preserva el estado previo de {@code config.properties} y lo
+ * restaura en {@code @AfterEach} para no alterar la preferencia del desarrollador.
+ */
+@DisplayName("PRU-006-01 | InventarioApp — leerTema y aplicarTema (MR-006)")
+class InventarioAppTemaTest {
+
+    private static final String CONFIG = "config.properties";
+    private String contenidoOriginal = null;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        File f = new File(CONFIG);
+        if (f.exists()) {
+            contenidoOriginal = new String(Files.readAllBytes(f.toPath()));
+        }
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        File f = new File(CONFIG);
+        if (contenidoOriginal != null) {
+            try (FileWriter fw = new FileWriter(f)) {
+                fw.write(contenidoOriginal);
+            }
+        } else {
+            f.delete();
+        }
+        contenidoOriginal = null;
+    }
+
+    // =========================================================================
+    // TC-01: sin config.properties → retorna "light" por defecto
+    // =========================================================================
+
+    @Test
+    @DisplayName("TC-01: leerTema sin config.properties retorna 'light' por defecto")
+    void tc01_leerTema_sinArchivo_retornaLight() {
+        new File(CONFIG).delete();
+
+        assertEquals("light", InventarioApp.leerTema(),
+            "Sin archivo de configuración debe retornar 'light' como valor por defecto");
+    }
+
+    // =========================================================================
+    // TC-02: config.properties con theme=dark → retorna "dark"
+    // =========================================================================
+
+    @Test
+    @DisplayName("TC-02: leerTema con theme=dark en config.properties retorna 'dark'")
+    void tc02_leerTema_archivoConDark_retornaDark() throws IOException {
+        Properties p = new Properties();
+        p.setProperty("theme", "dark");
+        try (FileOutputStream fos = new FileOutputStream(CONFIG)) {
+            p.store(fos, null);
+        }
+
+        assertEquals("dark", InventarioApp.leerTema(),
+            "Con theme=dark en config.properties debe retornar 'dark'");
+    }
+
+    // =========================================================================
+    // TC-03: config.properties con theme=light → retorna "light"
+    // =========================================================================
+
+    @Test
+    @DisplayName("TC-03: leerTema con theme=light en config.properties retorna 'light'")
+    void tc03_leerTema_archivoConLight_retornaLight() throws IOException {
+        Properties p = new Properties();
+        p.setProperty("theme", "light");
+        try (FileOutputStream fos = new FileOutputStream(CONFIG)) {
+            p.store(fos, null);
+        }
+
+        assertEquals("light", InventarioApp.leerTema(),
+            "Con theme=light en config.properties debe retornar 'light'");
+    }
+
+    // =========================================================================
+    // TC-04: config.properties existe pero sin clave "theme" → retorna "light"
+    // =========================================================================
+
+    @Test
+    @DisplayName("TC-04: leerTema con archivo sin clave 'theme' retorna 'light' por defecto")
+    void tc04_leerTema_archivoSinClave_retornaLight() throws IOException {
+        Properties p = new Properties();
+        p.setProperty("otra_clave", "valor");
+        try (FileOutputStream fos = new FileOutputStream(CONFIG)) {
+            p.store(fos, null);
+        }
+
+        assertEquals("light", InventarioApp.leerTema(),
+            "Si la clave 'theme' no está definida debe retornar 'light'");
+    }
+
+    // =========================================================================
+    // TC-05: aplicarTema("light") no lanza excepción
+    // =========================================================================
+
+    @Test
+    @DisplayName("TC-05: aplicarTema('light') aplica FlatLightLaf sin lanzar excepción")
+    void tc05_aplicarTema_light_noLanzaExcepcion() {
+        assertDoesNotThrow(() -> InventarioApp.aplicarTema("light"),
+            "aplicarTema('light') no debe lanzar ninguna excepción");
+    }
+
+    // =========================================================================
+    // TC-06: aplicarTema("dark") no lanza excepción
+    // =========================================================================
+
+    @Test
+    @DisplayName("TC-06: aplicarTema('dark') aplica FlatDarkLaf sin lanzar excepción")
+    void tc06_aplicarTema_dark_noLanzaExcepcion() {
+        assertDoesNotThrow(() -> InventarioApp.aplicarTema("dark"),
+            "aplicarTema('dark') no debe lanzar ninguna excepción");
+    }
+}

--- a/config.properties
+++ b/config.properties
@@ -1,0 +1,3 @@
+#MR-006 \u2013 OPC-A: preferencia de tema visual
+#Fri May 22 17:56:48 CST 2026
+theme=light


### PR DESCRIPTION
## Cambios

- Agrega dependencia FlatLaf 3.4.1 en pom.xml; crea config.properties con clave theme=light como preferencia por defecto; InventarioApp lee config.properties al arrancar mediante leerTema() y aplica FlatLightLaf o FlatDarkLaf vía aplicarTema(String) antes de construir la UI; si el archivo no existe o la clave no está definida, aplica FlatLightLaf por defecto sin lanzar excepción
- Agrega botón JToggleButton "Tema: Claro/Oscuro" en el panel superior derecho de InventarioView; al pulsarse cambia el Look & Feel en tiempo de ejecución con UIManager.setLookAndFeel y actualiza todos los componentes con SwingUtilities.updateComponentTreeUI; el nuevo tema se persiste en config.properties mediante guardarTema(String); el estado inicial del botón refleja la preferencia guardada en config.properties al abrir la vista
- Sin cambios en esquema de BD, lógica de negocio, validaciones de caducidad/existencias (MR-004), módulo de personalización y exportación HTML (MR-005) ni colores de alerta en InventarioView y ApartadosView (MR-003/MR-004)

## Pruebas

- 6 pruebas unitarias automáticas (PRU-006-01 — InventarioAppTemaTest):
todas pasaron ✓
- 7 pruebas funcionales manuales (PRU-006-02): todas pasaron ✓
- 10 pruebas de regresión (PRU-006-03, incluye mvn test 42/42 PASS): todas pasaron ✓
Ver Plantillas 9 para detalle de casos en la subcarpeta del MR en el canal de Teams
(PRU-006-01 / PRU-006-02 / PRU-006-03)