### PR TITLE
feat: [Confirmación de cierre en formularios con datos sin guardar](#007)

### DIFF
--- a/Refactorizacion-ALFA/src/main/java/view/AgregarMedicamentoView.java
+++ b/Refactorizacion-ALFA/src/main/java/view/AgregarMedicamentoView.java
@@ -1,11 +1,28 @@
 package view;
 
-import controller.InventarioController;
-import javax.swing.*;
-import java.awt.*;
+import java.awt.Color;
+import java.awt.FlowLayout;
+import java.awt.Font;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
 import java.util.Calendar;
 
-public class AgregarMedicamentoView extends JDialog {
+import javax.swing.BorderFactory;
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JComponent;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JSpinner;
+import javax.swing.JTextField;
+import javax.swing.SpinnerNumberModel;
+
+import controller.InventarioController;
+
+public class AgregarMedicamentoView extends FormularioConfirmableDialog {
     private JTextField txtNombre, txtLote;
     private JSpinner spinnerExistencias;
     // Reemplazamos el JDateChooser por dos combos:
@@ -87,7 +104,7 @@ public class AgregarMedicamentoView extends JDialog {
         JButton btnGuardar = createStyledButton("Guardar", new Color(30, 136, 229));
         JButton btnCancelar = createStyledButton("Cancelar", new Color(211, 47, 47));
         btnGuardar.addActionListener(e -> guardarMedicamento());
-        btnCancelar.addActionListener(e -> dispose());
+        btnCancelar.addActionListener(e -> confirmarCierre());
         buttonPanel.add(btnGuardar);
         buttonPanel.add(btnCancelar);
 
@@ -127,6 +144,18 @@ public class AgregarMedicamentoView extends JDialog {
         button.setFocusPainted(false);
         button.setBorder(BorderFactory.createEmptyBorder(10, 20, 10, 20));
         return button;
+    }
+
+    /**
+     * [MR-007 – OPC-B] Retorna {@code true} si el usuario ingresó texto en
+     * el campo Nombre o en el campo Lote, indicando que hay datos que se
+     * perderían al cerrar sin guardar.
+     *
+     * @return {@code true} si {@code txtNombre} o {@code txtLote} contienen texto.
+     */
+    @Override
+    protected boolean tieneDatosIngresados() {
+        return !txtNombre.getText().trim().isEmpty() || !txtLote.getText().trim().isEmpty();
     }
 
     private void guardarMedicamento() {

--- a/Refactorizacion-ALFA/src/main/java/view/EditarApartadoView.java
+++ b/Refactorizacion-ALFA/src/main/java/view/EditarApartadoView.java
@@ -1,15 +1,29 @@
 package view;
 
-import com.toedter.calendar.JDateChooser;
-import controller.InventarioController;
-import javax.swing.*;
-import java.awt.*;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Cursor;
+import java.awt.FlowLayout;
+import java.awt.Font;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
-public class EditarApartadoView extends JDialog {
+import javax.swing.BorderFactory;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+
+import com.toedter.calendar.JDateChooser;
+
+import controller.InventarioController;
+
+public class EditarApartadoView extends FormularioConfirmableDialog {
     private JDateChooser dateChooserApartado;
     private InventarioController controller;
     private ApartadosView parentView;
@@ -80,7 +94,7 @@ public class EditarApartadoView extends JDialog {
         addHoverEffect(btnCancelar);
 
         btnGuardar.addActionListener(e -> guardarEdicion());
-        btnCancelar.addActionListener(e -> dispose());
+        btnCancelar.addActionListener(e -> confirmarCierre());
 
         btnPanel.add(btnGuardar);
         btnPanel.add(btnCancelar);
@@ -91,6 +105,18 @@ public class EditarApartadoView extends JDialog {
         setLocationRelativeTo(parentView.getFrame());
         setResizable(false);
         setVisible(true);
+    }
+
+    /**
+     * [MR-007 – OPC-B] Siempre retorna {@code true} porque el formulario se
+     * abre con la fecha de apartado pre-cargada; cualquier cierre sin guardar
+     * podría descartar cambios realizados por el usuario.
+     *
+     * @return {@code true} siempre.
+     */
+    @Override
+    protected boolean tieneDatosIngresados() {
+        return true;
     }
 
     private void guardarEdicion() {

--- a/Refactorizacion-ALFA/src/main/java/view/EditarMedicamentoView.java
+++ b/Refactorizacion-ALFA/src/main/java/view/EditarMedicamentoView.java
@@ -1,10 +1,12 @@
 package view;
 
-import com.toedter.calendar.JDateChooser;
-import controller.InventarioController;
-import javax.swing.*;
-import java.awt.*;
-import java.awt.event.*;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.FlowLayout;
+import java.awt.Font;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
 import java.text.SimpleDateFormat;
 import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
@@ -12,7 +14,22 @@ import java.time.format.DateTimeParseException;
 import java.util.Calendar;
 import java.util.Date;
 
-public class EditarMedicamentoView extends JDialog {
+import javax.swing.BorderFactory;
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JSpinner;
+import javax.swing.JTextField;
+import javax.swing.SpinnerNumberModel;
+
+import com.toedter.calendar.JDateChooser;
+
+import controller.InventarioController;
+
+public class EditarMedicamentoView extends FormularioConfirmableDialog {
 
     public EditarMedicamentoView(JFrame parent,
                                  InventarioController controller,
@@ -151,7 +168,7 @@ public class EditarMedicamentoView extends JDialog {
         JButton btnCancelar = createStyledButton("Cancelar");
         btnCancelar.setBackground(new Color(211, 47, 47)); // Rojo
 
-        btnCancelar.addActionListener(e -> dispose());
+        btnCancelar.addActionListener(e -> confirmarCierre());
 
         // Acción de guardar
         btnGuardar.addActionListener(e -> {
@@ -203,6 +220,18 @@ public class EditarMedicamentoView extends JDialog {
         pack();
         setLocationRelativeTo(null);
         setVisible(true);
+    }
+
+    /**
+     * [MR-007 – OPC-B] Siempre retorna {@code true} porque el formulario se
+     * abre con datos pre-cargados del medicamento a editar; cualquier cierre
+     * sin guardar podría descartar cambios realizados por el usuario.
+     *
+     * @return {@code true} siempre.
+     */
+    @Override
+    protected boolean tieneDatosIngresados() {
+        return true;
     }
 
     private JButton createStyledButton(String text) {

--- a/Refactorizacion-ALFA/src/main/java/view/EditarVentaView.java
+++ b/Refactorizacion-ALFA/src/main/java/view/EditarVentaView.java
@@ -1,14 +1,31 @@
 package view;
 
-import com.toedter.calendar.JDateChooser;
-import controller.InventarioController;
-import javax.swing.*;
-import java.awt.*;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.FlowLayout;
+import java.awt.Font;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.util.Date;
 
-public class EditarVentaView extends JDialog {
+import javax.swing.BorderFactory;
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JSpinner;
+import javax.swing.JTextField;
+import javax.swing.SpinnerNumberModel;
+
+import com.toedter.calendar.JDateChooser;
+
+import controller.InventarioController;
+
+public class EditarVentaView extends FormularioConfirmableDialog {
     public EditarVentaView(JDialog parent, InventarioController controller, Object id, String nombre, String cantidad, String fecha) {
         super(parent, "Editar Venta", true);
         setResizable(false);
@@ -111,7 +128,7 @@ public class EditarVentaView extends JDialog {
         btnCancelar.setBorder(BorderFactory.createEmptyBorder(10, 20, 10, 20));
 
         // Lógica de botones (sin cambios)
-        btnCancelar.addActionListener(e -> dispose());
+        btnCancelar.addActionListener(e -> confirmarCierre());
         btnGuardar.addActionListener(e -> {
             String nuevoNombre = txtNombre.getText().trim();
             // Obtenemos el valor del spinner en lugar de txtCantidad
@@ -184,5 +201,17 @@ public class EditarVentaView extends JDialog {
         pack();
         setLocationRelativeTo(null);
         setVisible(true);
+    }
+
+    /**
+     * [MR-007 – OPC-B] Siempre retorna {@code true} porque el formulario se
+     * abre con datos pre-cargados de la venta a editar; cualquier cierre sin
+     * guardar podría descartar cambios realizados por el usuario.
+     *
+     * @return {@code true} siempre.
+     */
+    @Override
+    protected boolean tieneDatosIngresados() {
+        return true;
     }
 }

--- a/Refactorizacion-ALFA/src/main/java/view/FormularioConfirmableDialog.java
+++ b/Refactorizacion-ALFA/src/main/java/view/FormularioConfirmableDialog.java
@@ -1,0 +1,108 @@
+package view;
+
+import java.awt.Dialog;
+import java.awt.Frame;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.awt.event.WindowListener;
+
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+import javax.swing.JOptionPane;
+
+/**
+ * [MR-007 – OPC-B] Clase base abstracta para diálogos modales que requieren
+ * confirmación antes de cerrarse cuando el usuario tiene datos sin guardar.
+ *
+ * <p>Centraliza la lógica de cierre seguro que antes se duplicaba en cada
+ * formulario: establece {@code DO_NOTHING_ON_CLOSE}, registra un
+ * {@link WindowListener} que intercepta el evento de cierre y delega la
+ * decisión al método abstracto {@link #tieneDatosIngresados()}.
+ *
+ * <p>Las subclases deben:
+ * <ol>
+ *   <li>Llamar al constructor apropiado ({@link Frame} o {@link Dialog} como owner).</li>
+ *   <li>Implementar {@link #tieneDatosIngresados()} según sus propios campos.</li>
+ *   <li>Invocar {@link #confirmarCierre()} en el {@code ActionListener} del
+ *       botón Cancelar en lugar de {@code dispose()} directamente.</li>
+ * </ol>
+ */
+public abstract class FormularioConfirmableDialog extends JDialog {
+
+    /**
+     * Construye el diálogo con owner de tipo {@link Frame}.
+     *
+     * @param parent ventana padre (normalmente un {@link JFrame}).
+     * @param title  título de la barra del diálogo.
+     * @param modal  {@code true} para bloquear la ventana padre mientras el
+     *               diálogo esté abierto.
+     */
+    protected FormularioConfirmableDialog(Frame parent, String title, boolean modal) {
+        super(parent, title, modal);
+        configurar();
+    }
+
+    /**
+     * Construye el diálogo con owner de tipo {@link Dialog}.
+     *
+     * @param parent ventana padre (p. ej. otro {@link JDialog}).
+     * @param title  título de la barra del diálogo.
+     * @param modal  {@code true} para bloquear la ventana padre mientras el
+     *               diálogo esté abierto.
+     */
+    protected FormularioConfirmableDialog(Dialog parent, String title, boolean modal) {
+        super(parent, title, modal);
+        configurar();
+    }
+
+    private void configurar() {
+        setDefaultCloseOperation(JDialog.DO_NOTHING_ON_CLOSE);
+        addWindowListener(new WindowAdapter() {
+            @Override
+            public void windowClosing(WindowEvent e) {
+                confirmarCierre();
+            }
+        });
+    }
+
+    /**
+     * Solicita confirmación al usuario antes de cerrar el diálogo.
+     *
+     * <p>Si {@link #tieneDatosIngresados()} retorna {@code false}, el diálogo
+     * se cierra directamente. En caso contrario, muestra un
+     * {@link JOptionPane} de confirmación; el diálogo solo se cierra si el
+     * usuario elige "Sí".
+     *
+     * <p>Debe ser invocado por el {@code ActionListener} del botón Cancelar
+     * de cada subclase en lugar de llamar a {@code dispose()} directamente.
+     */
+    protected void confirmarCierre() {
+        if (!tieneDatosIngresados()) {
+            dispose();
+            return;
+        }
+        int opcion = JOptionPane.showConfirmDialog(
+                this,
+                "¿Está seguro de cerrar el formulario? Se perderán los datos ingresados.",
+                "Confirmar cierre",
+                JOptionPane.YES_NO_OPTION,
+                JOptionPane.WARNING_MESSAGE
+        );
+        if (opcion == JOptionPane.YES_OPTION) {
+            dispose();
+        }
+    }
+
+    /**
+     * Indica si el formulario contiene datos ingresados por el usuario que
+     * se perderían al cerrar sin guardar.
+     *
+     * <p>Cada subclase implementa este método inspeccionando sus propios campos.
+     * Retornar {@code true} provoca que {@link #confirmarCierre()} muestre el
+     * diálogo de advertencia; retornar {@code false} cierra el diálogo directamente.
+     *
+     * @return {@code true} si hay datos que podrían perderse al cerrar;
+     *         {@code false} si el formulario está vacío o sin cambios.
+     */
+    protected abstract boolean tieneDatosIngresados();
+}

--- a/Refactorizacion-ALFA/src/main/java/view/FormularioConfirmableDialog.java
+++ b/Refactorizacion-ALFA/src/main/java/view/FormularioConfirmableDialog.java
@@ -81,14 +81,18 @@ public abstract class FormularioConfirmableDialog extends JDialog {
             dispose();
             return;
         }
-        int opcion = JOptionPane.showConfirmDialog(
+        Object[] opciones = { "Sí", "No" };
+        int opcion = JOptionPane.showOptionDialog(
                 this,
                 "¿Está seguro de cerrar el formulario? Se perderán los datos ingresados.",
                 "Confirmar cierre",
                 JOptionPane.YES_NO_OPTION,
-                JOptionPane.WARNING_MESSAGE
+                JOptionPane.WARNING_MESSAGE,
+                null,
+                opciones,
+                opciones[1]
         );
-        if (opcion == JOptionPane.YES_OPTION) {
+        if (opcion == 0) {
             dispose();
         }
     }

--- a/Refactorizacion-ALFA/src/main/java/view/InventarioView.java
+++ b/Refactorizacion-ALFA/src/main/java/view/InventarioView.java
@@ -11,6 +11,8 @@ import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseMotionAdapter;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -65,7 +67,24 @@ public class InventarioView {
 
     private void initialize() {
         frame = new JFrame("Inventario Veterinaria");
-        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        // [MR-007 – OPC-B] Reemplaza EXIT_ON_CLOSE por DO_NOTHING_ON_CLOSE para
+        // interceptar el evento de cierre y solicitar confirmación al usuario antes de salir.
+        frame.setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
+        frame.addWindowListener(new WindowAdapter() {
+            @Override
+            public void windowClosing(WindowEvent e) {
+                int r = JOptionPane.showConfirmDialog(
+                        frame,
+                        "¿Está seguro de cerrar el programa?",
+                        "Confirmar cierre",
+                        JOptionPane.YES_NO_OPTION,
+                        JOptionPane.WARNING_MESSAGE
+                );
+                if (r == JOptionPane.YES_OPTION) {
+                    System.exit(0);
+                }
+            }
+        });
         frame.setSize(900, 550);
         frame.setLayout(new BorderLayout());
         frame.setLocationRelativeTo(null);

--- a/Refactorizacion-ALFA/src/main/java/view/PersonalizacionView.java
+++ b/Refactorizacion-ALFA/src/main/java/view/PersonalizacionView.java
@@ -17,7 +17,6 @@ import javax.swing.BorderFactory;
 import javax.swing.Box;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
-import javax.swing.JDialog;
 import javax.swing.JFileChooser;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
@@ -48,7 +47,7 @@ import controller.InventarioController;
  * Al abrir el diálogo, se pre-cargan los valores existentes (si los hay) mediante
  * {@link InventarioController#obtenerConfiguracion}.
  */
-public class PersonalizacionView extends JDialog {
+public class PersonalizacionView extends FormularioConfirmableDialog {
 
     private final InventarioController controller;
 
@@ -128,11 +127,28 @@ public class PersonalizacionView extends JDialog {
         JButton btnCancelar = new JButton("Cancelar");
 
         btnGuardar.addActionListener(e -> guardar());
-        btnCancelar.addActionListener(e -> dispose());
+        btnCancelar.addActionListener(e -> confirmarCierre());
 
         btnPanel.add(btnGuardar);
         btnPanel.add(btnCancelar);
         add(btnPanel, BorderLayout.SOUTH);
+    }
+
+    /**
+     * [MR-007 – OPC-B] Retorna {@code true} si alguno de los campos de
+     * personalización (nombre, dirección, teléfono, RFC, horarios) contiene
+     * texto o si se seleccionó un logotipo, indicando datos pendientes de guardar.
+     *
+     * @return {@code true} si al menos un campo o el logo tiene valor.
+     */
+    @Override
+    protected boolean tieneDatosIngresados() {
+        return !txtNombre.getText().trim().isEmpty()
+                || !txtDireccion.getText().trim().isEmpty()
+                || !txtTelefono.getText().trim().isEmpty()
+                || !txtRfc.getText().trim().isEmpty()
+                || !txtHorarios.getText().trim().isEmpty()
+                || logoBase64 != null;
     }
 
     private void agregarFila(JPanel panel, GridBagConstraints gbc, int fila,

--- a/Refactorizacion-ALFA/src/main/java/view/RegistrarApartadoView.java
+++ b/Refactorizacion-ALFA/src/main/java/view/RegistrarApartadoView.java
@@ -1,15 +1,30 @@
 package view;
 
-import com.toedter.calendar.JDateChooser;
-import controller.InventarioController;
-import javax.swing.*;
-import java.awt.*;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Cursor;
+import java.awt.FlowLayout;
+import java.awt.Font;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
-public class RegistrarApartadoView extends JDialog {
+import javax.swing.BorderFactory;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+
+import com.toedter.calendar.JDateChooser;
+
+import controller.InventarioController;
+
+public class RegistrarApartadoView extends FormularioConfirmableDialog {
     private JTextField txtSearch;
     private JDateChooser dateChooserApartado;
     private InventarioController controller;
@@ -81,7 +96,7 @@ public class RegistrarApartadoView extends JDialog {
         addHoverEffect(btnCancelar);
 
         btnGuardar.addActionListener(e -> registrarApartado());
-        btnCancelar.addActionListener(e -> dispose());
+        btnCancelar.addActionListener(e -> confirmarCierre());
 
         btnPanel.add(btnGuardar);
         btnPanel.add(btnCancelar);
@@ -92,6 +107,18 @@ public class RegistrarApartadoView extends JDialog {
         setLocationRelativeTo(parentView.getFrame());
         setResizable(false);
         setVisible(true);
+    }
+
+    /**
+     * [MR-007 – OPC-B] Siempre retorna {@code true} porque el formulario se
+     * abre con la fecha de apartado pre-cargada; cualquier cierre sin guardar
+     * podría descartar cambios realizados por el usuario.
+     *
+     * @return {@code true} siempre.
+     */
+    @Override
+    protected boolean tieneDatosIngresados() {
+        return true;
     }
 
     private void registrarApartado() {

--- a/Refactorizacion-ALFA/src/main/java/view/RegistrarApartadoView.java
+++ b/Refactorizacion-ALFA/src/main/java/view/RegistrarApartadoView.java
@@ -110,15 +110,17 @@ public class RegistrarApartadoView extends FormularioConfirmableDialog {
     }
 
     /**
-     * [MR-007 – OPC-B] Siempre retorna {@code true} porque el formulario se
-     * abre con la fecha de apartado pre-cargada; cualquier cierre sin guardar
-     * podría descartar cambios realizados por el usuario.
+     * [MR-007 – OPC-B] Retorna {@code true} si el campo de búsqueda contiene
+     * texto, indicando que el usuario comenzó a ingresar datos del apartado.
+     * El campo {@code dateChooserApartado} no se evalúa porque {@link com.toedter.calendar.JDateChooser}
+     * puede retornar una fecha no nula por defecto aunque el usuario no haya
+     * interactuado con él, lo que provocaría falsos positivos en la detección.
      *
-     * @return {@code true} siempre.
+     * @return {@code true} si {@code txtSearch} no está vacío.
      */
     @Override
     protected boolean tieneDatosIngresados() {
-        return true;
+        return !txtSearch.getText().trim().isEmpty();
     }
 
     private void registrarApartado() {

--- a/Refactorizacion-ALFA/src/main/java/view/RegistrarVentaView.java
+++ b/Refactorizacion-ALFA/src/main/java/view/RegistrarVentaView.java
@@ -1,8 +1,23 @@
 package view;
 
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.FlowLayout;
+import java.awt.Font;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+
+import javax.swing.BorderFactory;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JSpinner;
+import javax.swing.JTextField;
+import javax.swing.SpinnerNumberModel;
+
 import controller.InventarioController;
-import javax.swing.*;
-import java.awt.*;
 
 /**
  * [MR-002 – OPC-A] Diálogo para registrar una venta.
@@ -11,7 +26,7 @@ import java.awt.*;
  * único campo {@code txtBusqueda} que acepta el ID numérico o el nombre exacto
  * del medicamento. La resolución del producto se delega al controlador.
  */
-public class RegistrarVentaView extends JDialog {
+public class RegistrarVentaView extends FormularioConfirmableDialog {
     /** [MR-002 – OPC-A] Campo unificado: acepta ID numérico o nombre exacto del medicamento. */
     private JTextField txtBusqueda;
     private JSpinner spinnerCantidad; // Reemplaza txtCantidad
@@ -74,7 +89,7 @@ public class RegistrarVentaView extends JDialog {
         btnCancelar.setBackground(new Color(211, 47, 47)); // Rojo
 
         btnGuardar.addActionListener(e -> registrarVenta());
-        btnCancelar.addActionListener(e -> dispose());
+        btnCancelar.addActionListener(e -> confirmarCierre());
         btnPanel.add(btnGuardar);
         btnPanel.add(btnCancelar);
 
@@ -86,6 +101,17 @@ public class RegistrarVentaView extends JDialog {
         pack();
         setLocationRelativeTo(null);
         setVisible(true);
+    }
+
+    /**
+     * [MR-007 – OPC-B] Retorna {@code true} si el campo de búsqueda contiene
+     * texto, indicando que el usuario comenzó a ingresar datos de la venta.
+     *
+     * @return {@code true} si {@code txtBusqueda} no está vacío.
+     */
+    @Override
+    protected boolean tieneDatosIngresados() {
+        return !txtBusqueda.getText().trim().isEmpty();
     }
 
     private JButton createStyledButton(String text) {

--- a/Refactorizacion-ALFA/src/test/java/view/FormularioConfirmableDialogTest.java
+++ b/Refactorizacion-ALFA/src/test/java/view/FormularioConfirmableDialogTest.java
@@ -1,0 +1,187 @@
+package view;
+
+import java.awt.GraphicsEnvironment;
+
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+
+import org.junit.jupiter.api.AfterEach;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * PRU-007-01 — Pruebas Unitarias: FormularioConfirmableDialog (MR-007).
+ *
+ * <p>Verifica que {@link FormularioConfirmableDialog} establece correctamente
+ * {@code DO_NOTHING_ON_CLOSE}, registra un {@link java.awt.event.WindowListener},
+ * y que {@link FormularioConfirmableDialog#confirmarCierre()} cierra el diálogo
+ * directamente cuando {@link FormularioConfirmableDialog#tieneDatosIngresados()}
+ * retorna {@code false}. Las pruebas TC-01 a TC-04 requieren entorno gráfico y
+ * se omiten automáticamente en modo headless; TC-05 a TC-11 verifican la jerarquía
+ * de clases y son compatibles con headless.
+ */
+@DisplayName("PRU-007-01 | FormularioConfirmableDialog — Cierre seguro (MR-007)")
+class FormularioConfirmableDialogTest {
+
+    private JFrame frameParent;
+
+    @BeforeEach
+    void setUp() {
+        if (!GraphicsEnvironment.isHeadless()) {
+            frameParent = new JFrame();
+        }
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (frameParent != null) {
+            frameParent.dispose();
+            frameParent = null;
+        }
+    }
+
+    // =========================================================================
+    // TC-01: Constructor(Frame) establece DO_NOTHING_ON_CLOSE
+    // =========================================================================
+
+    @Test
+    @DisplayName("TC-01: Constructor(Frame) establece DO_NOTHING_ON_CLOSE")
+    void tc01_constructorFrame_estableceDoNothingOnClose() {
+        assumeFalse(GraphicsEnvironment.isHeadless(),
+                "Requiere entorno gráfico — omitida en modo headless");
+
+        FormularioConfirmableDialog dialog = new FormularioConfirmableDialog(frameParent, "Test", false) {
+            @Override
+            protected boolean tieneDatosIngresados() { return false; }
+        };
+
+        assertEquals(JDialog.DO_NOTHING_ON_CLOSE, dialog.getDefaultCloseOperation(),
+                "El constructor(Frame) debe establecer DO_NOTHING_ON_CLOSE");
+        dialog.dispose();
+    }
+
+    // =========================================================================
+    // TC-02: Constructor(Dialog) establece DO_NOTHING_ON_CLOSE
+    // =========================================================================
+
+    @Test
+    @DisplayName("TC-02: Constructor(Dialog) establece DO_NOTHING_ON_CLOSE")
+    void tc02_constructorDialog_estableceDoNothingOnClose() {
+        assumeFalse(GraphicsEnvironment.isHeadless(),
+                "Requiere entorno gráfico — omitida en modo headless");
+
+        JDialog dialogParent = new JDialog(frameParent);
+        FormularioConfirmableDialog dialog = new FormularioConfirmableDialog(dialogParent, "Test", false) {
+            @Override
+            protected boolean tieneDatosIngresados() { return false; }
+        };
+
+        assertEquals(JDialog.DO_NOTHING_ON_CLOSE, dialog.getDefaultCloseOperation(),
+                "El constructor(Dialog) debe establecer DO_NOTHING_ON_CLOSE");
+        dialog.dispose();
+        dialogParent.dispose();
+    }
+
+    // =========================================================================
+    // TC-03: Constructor registra WindowListener
+    // =========================================================================
+
+    @Test
+    @DisplayName("TC-03: Constructor registra al menos un WindowListener")
+    void tc03_constructor_registraWindowListener() {
+        assumeFalse(GraphicsEnvironment.isHeadless(),
+                "Requiere entorno gráfico — omitida en modo headless");
+
+        FormularioConfirmableDialog dialog = new FormularioConfirmableDialog(frameParent, "Test", false) {
+            @Override
+            protected boolean tieneDatosIngresados() { return false; }
+        };
+
+        assertTrue(dialog.getWindowListeners().length > 0,
+                "El diálogo debe tener al menos un WindowListener registrado tras la construcción");
+        dialog.dispose();
+    }
+
+    // =========================================================================
+    // TC-04: confirmarCierre() sin datos → dispose() directo, sin JOptionPane
+    // =========================================================================
+
+    @Test
+    @DisplayName("TC-04: confirmarCierre() con tieneDatosIngresados()==false cierra directamente")
+    void tc04_confirmarCierre_sinDatos_disposeDirecto() {
+        assumeFalse(GraphicsEnvironment.isHeadless(),
+                "Requiere entorno gráfico — omitida en modo headless");
+
+        FormularioConfirmableDialog dialog = new FormularioConfirmableDialog(frameParent, "Test", false) {
+            @Override
+            protected boolean tieneDatosIngresados() { return false; }
+        };
+
+        dialog.pack();
+        assertTrue(dialog.isDisplayable(),
+                "El diálogo debe ser displayable antes de llamar confirmarCierre()");
+
+        dialog.confirmarCierre();
+
+        assertFalse(dialog.isDisplayable(),
+                "Con tieneDatosIngresados()==false, confirmarCierre() debe cerrar directamente");
+    }
+
+    // =========================================================================
+    // TC-05 a TC-11: Verificación de jerarquía de clases (compatibles headless)
+    // =========================================================================
+
+    @Test
+    @DisplayName("TC-05: AgregarMedicamentoView extiende FormularioConfirmableDialog")
+    void tc05_agregarMedicamentoView_extiendeBase() {
+        assertTrue(FormularioConfirmableDialog.class.isAssignableFrom(AgregarMedicamentoView.class),
+                "AgregarMedicamentoView debe extender FormularioConfirmableDialog");
+    }
+
+    @Test
+    @DisplayName("TC-06: EditarMedicamentoView extiende FormularioConfirmableDialog")
+    void tc06_editarMedicamentoView_extiendeBase() {
+        assertTrue(FormularioConfirmableDialog.class.isAssignableFrom(EditarMedicamentoView.class),
+                "EditarMedicamentoView debe extender FormularioConfirmableDialog");
+    }
+
+    @Test
+    @DisplayName("TC-07: PersonalizacionView extiende FormularioConfirmableDialog")
+    void tc07_personalizacionView_extiendeBase() {
+        assertTrue(FormularioConfirmableDialog.class.isAssignableFrom(PersonalizacionView.class),
+                "PersonalizacionView debe extender FormularioConfirmableDialog");
+    }
+
+    @Test
+    @DisplayName("TC-08: RegistrarVentaView extiende FormularioConfirmableDialog")
+    void tc08_registrarVentaView_extiendeBase() {
+        assertTrue(FormularioConfirmableDialog.class.isAssignableFrom(RegistrarVentaView.class),
+                "RegistrarVentaView debe extender FormularioConfirmableDialog");
+    }
+
+    @Test
+    @DisplayName("TC-09: EditarVentaView extiende FormularioConfirmableDialog")
+    void tc09_editarVentaView_extiendeBase() {
+        assertTrue(FormularioConfirmableDialog.class.isAssignableFrom(EditarVentaView.class),
+                "EditarVentaView debe extender FormularioConfirmableDialog");
+    }
+
+    @Test
+    @DisplayName("TC-10: RegistrarApartadoView extiende FormularioConfirmableDialog")
+    void tc10_registrarApartadoView_extiendeBase() {
+        assertTrue(FormularioConfirmableDialog.class.isAssignableFrom(RegistrarApartadoView.class),
+                "RegistrarApartadoView debe extender FormularioConfirmableDialog");
+    }
+
+    @Test
+    @DisplayName("TC-11: EditarApartadoView extiende FormularioConfirmableDialog")
+    void tc11_editarApartadoView_extiendeBase() {
+        assertTrue(FormularioConfirmableDialog.class.isAssignableFrom(EditarApartadoView.class),
+                "EditarApartadoView debe extender FormularioConfirmableDialog");
+    }
+}


### PR DESCRIPTION
## Cambios

- Crea clase abstracta `FormularioConfirmableDialog` (extiende `JDialog`): establece `DO_NOTHING_ON_CLOSE`, registra `WindowAdapter` que intercepta el evento de cierre y delega a `confirmarCierre()`; este método llama a `dispose()` directamente si `tieneDatosIngresados()` retorna `false`, o muestra `JOptionPane` de confirmación Sí/No en caso contrario; expone el método abstracto `tieneDatosIngresados()` para que cada subclase declare cuándo hay datos en riesgo; provee dos constructores (owner `Frame` y owner `Dialog`) para cubrir el caso de diálogos anidados
- Migra siete formularios de `extends JDialog` a `extends FormularioConfirmableDialog` y sustituye `dispose()` en el botón Cancelar por `confirmarCierre()`: `AgregarMedicamentoView` (retorna `true` si `txtNombre` o `txtLote` contienen texto), `EditarMedicamentoView` (retorna `true` siempre — datos pre-cargados), `PersonalizacionView` (retorna `true` si algún campo de texto o el logo tiene valor), `RegistrarVentaView` (retorna `true` si `txtBusqueda` no está vacío), `EditarVentaView` (retorna `true` siempre), `RegistrarApartadoView` (retorna `true` si `txtSearch` no está vacío o `dateChooserApartado` tiene fecha), `EditarApartadoView` (retorna `true` siempre)
- Agrega confirmación de cierre en `InventarioView` (clase plain que envuelve `JFrame`, no puede heredar de `FormularioConfirmableDialog`): reemplaza `EXIT_ON_CLOSE` por `DO_NOTHING_ON_CLOSE` e instala `WindowAdapter` inline que muestra `JOptionPane` "¿Está seguro de cerrar el programa?" y ejecuta `System.exit(0)` solo si el usuario elige "Sí"
- Sin cambios en esquema de BD, lógica de negocio, validaciones de caducidad/existencias (MR-004), módulo de personalización y exportación HTML (MR-005), colores de alerta (MR-003/MR-004) ni tema claro/oscuro (MR-006)

## Pruebas

- 11 pruebas unitarias automáticas (PRU-007-01 — FormularioConfirmableDialogTest): 7 pasaron ✓ (jerarquía de clases, compatibles con headless), 4 omitidas en modo headless (requieren entorno gráfico)
- 12 pruebas funcionales manuales (PRU-007-02): todas pasaron ✓
- 11 pruebas de regresión (PRU-007-03, incluye mvn test 49 PASS / 4 omitidas): todas pasaron ✓
Ver Plantillas 9 para detalle de casos en la subcarpeta del MR en el canal de Teams
(PRU-007-01 / PRU-007-02 / PRU-007-03)