### PR TITLE
MR-008: Manejo seguro de caducidad en InventarioDAO

### DIFF
--- a/Refactorizacion-ALFA/src/main/java/model/InventarioDAO.java
+++ b/Refactorizacion-ALFA/src/main/java/model/InventarioDAO.java
@@ -345,6 +345,36 @@ public class InventarioDAO {
         }
     }
 
+    /**
+     * Parsea y valida de forma segura la cadena de caducidad del producto.
+     * Centraliza la lógica de validación (regex {@code \d{4}-\d{2}}) y el parseo
+     * a {@link YearMonth} reutilizando lo ya implementado en {@link #validarFechaCaducidad}.
+     *
+     * <p>Diseñado para invocarse desde los 4 puntos vulnerables ({@code registrarVenta},
+     * {@code obtenerMedicamentosProximosACaducar}, {@code obtenerMedicamentosCaducados},
+     * {@code separarProducto}). Ante {@code null} debe interpretarse según el contexto:
+     * las consultas de alertas omiten el registro corrupto; las operaciones de venta/apartado
+     * retornan {@code false} con un mensaje claro al usuario.
+     *
+     * @param fechaCaducidad cadena en formato {@code yyyy-MM} (puede ser {@code null} o vacía).
+     * @return el {@link YearMonth} parseado, o {@code null} si la entrada es nula,
+     *         vacía o tiene formato inválido.
+     */
+    private YearMonth parsearCaducidad(String fechaCaducidad) {
+        if (fechaCaducidad == null || fechaCaducidad.isEmpty()) {
+            return null;
+        }
+        if (!fechaCaducidad.matches("\\d{4}-\\d{2}")) {
+            return null;
+        }
+        try {
+            DateTimeFormatter ymFormatter = DateTimeFormatter.ofPattern("yyyy-MM");
+            return YearMonth.parse(fechaCaducidad, ymFormatter);
+        } catch (DateTimeParseException e) {
+            return null;
+        }
+    }
+
     private boolean validarFechaCaducidad(String fechaCaducidad) {
         // Validar con expresión regular: 4 dígitos de año, guión, 2 dígitos de mes
         if (!fechaCaducidad.matches("\\d{4}-\\d{2}")) {

--- a/Refactorizacion-ALFA/src/main/java/model/InventarioDAO.java
+++ b/Refactorizacion-ALFA/src/main/java/model/InventarioDAO.java
@@ -445,7 +445,11 @@ public class InventarioDAO {
 
                 // [MR-003 OPC-A] Validar que el producto no esté caducado.
                 // Un producto caduca al inicio del mes siguiente al indicado en caducidad.
-                YearMonth cadYM = YearMonth.parse(caducidad, DateTimeFormatter.ofPattern("yyyy-MM"));
+                YearMonth cadYM = parsearCaducidad(caducidad);
+                if (cadYM == null) {
+                    JOptionPane.showMessageDialog(null, "No se puede registrar la venta: la caducidad del producto no tiene un formato válido", "Error", JOptionPane.ERROR_MESSAGE);
+                    return false;
+                }
                 LocalDate fechaExpiracion = cadYM.plusMonths(1).atDay(1);
                 if (!LocalDate.now().isBefore(fechaExpiracion)) {
                     JOptionPane.showMessageDialog(null, "No se puede registrar la venta: el medicamento está caducado", "Error", JOptionPane.ERROR_MESSAGE);

--- a/Refactorizacion-ALFA/src/main/java/model/InventarioDAO.java
+++ b/Refactorizacion-ALFA/src/main/java/model/InventarioDAO.java
@@ -376,18 +376,7 @@ public class InventarioDAO {
     }
 
     private boolean validarFechaCaducidad(String fechaCaducidad) {
-        // Validar con expresión regular: 4 dígitos de año, guión, 2 dígitos de mes
-        if (!fechaCaducidad.matches("\\d{4}-\\d{2}")) {
-            return false;
-        }
-        // O adicionalmente intentar parsear con YearMonth
-        try {
-            DateTimeFormatter ymFormatter = DateTimeFormatter.ofPattern("yyyy-MM");
-            YearMonth.parse(fechaCaducidad, ymFormatter);
-            return true; // si parsea, es válido
-        } catch (DateTimeParseException e) {
-            return false;
-        }
+        return parsearCaducidad(fechaCaducidad) != null;
     }
 
 

--- a/Refactorizacion-ALFA/src/main/java/model/InventarioDAO.java
+++ b/Refactorizacion-ALFA/src/main/java/model/InventarioDAO.java
@@ -801,7 +801,14 @@ public class InventarioDAO {
                     if (!rs.next()) return false;
                     String caducidadStr = rs.getString("caducidad");
                     int existencias = rs.getInt("existencias");
-                    YearMonth caducidad = YearMonth.parse(caducidadStr, DateTimeFormatter.ofPattern("yyyy-MM"));
+                    // [MR-003 OPC-A] Parseo seguro: ante caducidad corrupta, no se aparta.
+                    YearMonth caducidad = parsearCaducidad(caducidadStr);
+                    if (caducidad == null) {
+                        JOptionPane.showMessageDialog(null,
+                            "No se puede registrar el apartado: la caducidad del producto no tiene un formato válido",
+                            "Error", JOptionPane.ERROR_MESSAGE);
+                        return false;
+                    }
                     if (estaCaducado(caducidad)) {
                         JOptionPane.showMessageDialog(null,
                             "No se puede registrar el apartado: el medicamento está caducado",

--- a/Refactorizacion-ALFA/src/main/java/model/InventarioDAO.java
+++ b/Refactorizacion-ALFA/src/main/java/model/InventarioDAO.java
@@ -740,12 +740,15 @@ public class InventarioDAO {
         try (Statement stmt = connection.createStatement();
              ResultSet rs = stmt.executeQuery("SELECT * FROM productos")) {
 
-            DateTimeFormatter ymFormatter = DateTimeFormatter.ofPattern("yyyy-MM");
             LocalDate hoy = LocalDate.now();
 
             while (rs.next()) {
                 String caducidadStr = rs.getString("caducidad"); // "yyyy-MM"
-                YearMonth cadYM = YearMonth.parse(caducidadStr, ymFormatter);
+                // [MR-003 OPC-A] Parseo seguro: omitir registros con caducidad corrupta.
+                YearMonth cadYM = parsearCaducidad(caducidadStr);
+                if (cadYM == null) {
+                    continue;
+                }
                 // [MR-003 OPC-A] Expira el primer día del mes siguiente al indicado.
                 LocalDate primerDiaCaducidad = cadYM.plusMonths(1).atDay(1);
 

--- a/Refactorizacion-ALFA/src/main/java/model/InventarioDAO.java
+++ b/Refactorizacion-ALFA/src/main/java/model/InventarioDAO.java
@@ -694,13 +694,15 @@ public class InventarioDAO {
         try (Statement stmt = connection.createStatement();
              ResultSet rs = stmt.executeQuery("SELECT * FROM productos")) {
 
-            DateTimeFormatter ymFormatter = DateTimeFormatter.ofPattern("yyyy-MM");
             LocalDate hoy = LocalDate.now();
 
             while (rs.next()) {
                 String caducidadStr = rs.getString("caducidad"); // "yyyy-MM"
-                // Parseamos a YearMonth
-                YearMonth cadYM = YearMonth.parse(caducidadStr, ymFormatter);
+                // [MR-003 OPC-A] Parseo seguro: omitir registros con caducidad corrupta.
+                YearMonth cadYM = parsearCaducidad(caducidadStr);
+                if (cadYM == null) {
+                    continue;
+                }
 
                 // [MR-003 OPC-A] Expira el primer día del mes siguiente al indicado.
                 LocalDate primerDiaCaducidad = cadYM.plusMonths(1).atDay(1);

--- a/Refactorizacion-ALFA/src/main/java/view/InventarioView.java
+++ b/Refactorizacion-ALFA/src/main/java/view/InventarioView.java
@@ -381,7 +381,8 @@ public class InventarioView {
         String nombre = table.getValueAt(selectedRow, 1).toString();
         String existencias = table.getValueAt(selectedRow, 2).toString();
         String lote = table.getValueAt(selectedRow, 3).toString();
-        String caducidad = table.getValueAt(selectedRow, 4).toString();
+        Object rawCaducidad = table.getValueAt(selectedRow, 4);
+        String caducidad = rawCaducidad != null ? rawCaducidad.toString() : "";
         String fechaEntrada = table.getValueAt(selectedRow, 5).toString();
 
         new EditarMedicamentoView(

--- a/Refactorizacion-ALFA/src/test/java/model/InventarioDAOCaducidadTest.java
+++ b/Refactorizacion-ALFA/src/test/java/model/InventarioDAOCaducidadTest.java
@@ -212,4 +212,94 @@ class InventarioDAOCaducidadTest {
         assertFalse(caducados.isEmpty(),
             "Producto cuyo mes de caducidad ya pasó debe aparecer en la lista de caducados");
     }
+
+    // =========================================================================
+    // TC-09 a TC-13: parseo seguro de caducidad (MR-008 OPC-A)
+    // =========================================================================
+
+    @Test
+    @DisplayName("TC-09: registrarVenta con caducidad null → no registra venta")
+    void tc09_caducidadNull_registrarVentaNoRegistra() throws SQLException {
+        int id = insertarProducto("Med-Null", 10, null);
+
+        // En entorno headless el JOptionPane lanza HeadlessException antes del return false.
+        try {
+            dao.registrarVenta(id, "Med-Null", 1);
+        } catch (Exception ignored) {
+            // HeadlessException esperada
+        }
+
+        try (Statement stmt = connection.createStatement();
+             ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM historial_ventas")) {
+            assertTrue(rs.next());
+            assertEquals(0, rs.getInt(1),
+                "No debe existir registro en historial_ventas cuando la caducidad es null");
+        }
+    }
+
+    @Test
+    @DisplayName("TC-10: registrarVenta con caducidad vacía → no registra venta")
+    void tc10_caducidadVacia_registrarVentaNoRegistra() throws SQLException {
+        int id = insertarProducto("Med-Vacio", 10, "");
+
+        try {
+            dao.registrarVenta(id, "Med-Vacio", 1);
+        } catch (Exception ignored) {
+            // HeadlessException esperada
+        }
+
+        try (Statement stmt = connection.createStatement();
+             ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM historial_ventas")) {
+            assertTrue(rs.next());
+            assertEquals(0, rs.getInt(1),
+                "No debe existir registro en historial_ventas cuando la caducidad es vacía");
+        }
+    }
+
+    @Test
+    @DisplayName("TC-11: registrarVenta con caducidad mal formada → no registra venta")
+    void tc11_caducidadMalFormada_registrarVentaNoRegistra() throws SQLException {
+        int id = insertarProducto("Med-Basura", 10, "2025-13");
+
+        try {
+            dao.registrarVenta(id, "Med-Basura", 1);
+        } catch (Exception ignored) {
+            // HeadlessException esperada
+        }
+
+        try (Statement stmt = connection.createStatement();
+             ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM historial_ventas")) {
+            assertTrue(rs.next());
+            assertEquals(0, rs.getInt(1),
+                "No debe existir registro en historial_ventas cuando la caducidad está mal formada");
+        }
+    }
+
+    @Test
+    @DisplayName("TC-12: obtenerMedicamentosProximosACaducar omite fila corrupta y devuelve el resto")
+    void tc12_proximosACaducar_omiteCorruptoYDevuelveResto() throws SQLException {
+        insertarProducto("Med-Corrupto", 10, "no-es-fecha");
+        insertarProducto("Med-Valido", 10, caducidadMesActual());
+
+        var proximos = dao.obtenerMedicamentosProximosACaducar(31);
+
+        assertEquals(1, proximos.size(),
+            "Debe omitir el registro con caducidad corrupta y devolver solo el válido");
+        assertEquals("Med-Valido", proximos.get(0)[1],
+            "El registro devuelto debe corresponder al producto con caducidad válida");
+    }
+
+    @Test
+    @DisplayName("TC-13: obtenerMedicamentosCaducados omite fila corrupta y devuelve el resto")
+    void tc13_caducados_omiteCorruptoYDevuelveResto() throws SQLException {
+        insertarProducto("Med-Corrupto", 10, null);
+        insertarProducto("Med-Caducado", 10, caducidadExpirada());
+
+        var caducados = dao.obtenerMedicamentosCaducados();
+
+        assertEquals(1, caducados.size(),
+            "Debe omitir el registro con caducidad corrupta y devolver solo el caducado válido");
+        assertEquals("Med-Caducado", caducados.get(0)[1],
+            "El registro devuelto debe corresponder al producto con caducidad válida");
+    }
 }

--- a/Refactorizacion-ALFA/src/test/java/model/InventarioDAOSepararProductoTest.java
+++ b/Refactorizacion-ALFA/src/test/java/model/InventarioDAOSepararProductoTest.java
@@ -183,4 +183,23 @@ class InventarioDAOSepararProductoTest {
 
         assertFalse(resultado, "ID inexistente debe retornar false");
     }
+
+    // =========================================================================
+    // TC-06: Caducidad corrupta → sin apartado en BD (MR-008 OPC-A)
+    // =========================================================================
+
+    @Test
+    @DisplayName("TC-06: Producto con caducidad corrupta → separarProducto no registra apartado")
+    void tc06_caducidadCorrupta_noRegistraApartado() throws SQLException {
+        int id = insertarProducto("Med-Basura", 10, "no-es-fecha");
+
+        try {
+            dao.separarProducto(id, "2026-05-18");
+        } catch (Exception ignored) {
+            // HeadlessException esperada en entorno sin GUI; lo relevante es el estado de la BD
+        }
+
+        assertNull(fechaSeparadoEnBD(id),
+            "Producto con caducidad corrupta no debe tener fecha_separado registrada");
+    }
 }


### PR DESCRIPTION
# MR-008: Manejo seguro de caducidad en InventarioDAO

Closes #26

## Resumen de cambios
Refactor de la validación de caducidad en InventarioDAO. Se introduce parsearCaducidad() para un parseo seguro del campo caducidad (formato yyyy-MM), y se ajustan los métodos que lo consumen:
- registrarVenta(): rechaza ventas de productos caducados o con caducidad nula/vacía/mal formada, con mensajes diferenciados.
- separarProducto(): no aparta productos caducados, sin existencias o con caducidad corrupta.
- obtenerMedicamentosProximosACaducar() / obtenerMedicamentosCaducados(): omiten filas con caducidad corrupta sin lanzar excepción.

Archivos modificados: model/InventarioDAO.java (+ tests InventarioDAOCaducidadTest.java, InventarioDAOSepararProductoTest.java).

## Pruebas ejecutadas
Commit probado: f4dad50. Suite completa: 73 tests, BUILD SUCCESS, 0 fallos.

| Plantilla 9 | Tipo | Casos | Resultado |
|---|---|---|---|
| PRU-008-01 | Integración (caducidad) | 13 | 13/13 Aprobado |
| PRU-008-02 | Integración (separar) | 6 | 6/6 Aprobado |
| PRU-008-03 | Regresión | 9 | 9/9 Aprobado |
| PRU-008-04 | Funcional (GUI) | 11 | 11/11 Aprobado |

Plantillas 9 completas en Teams: MR-008/Fase 3 - Implementación/.

> Nota de entorno: ejecución en entorno equivalente disponible (sin Staging técnicamente diferenciado). Limitación documentada y autorizada por el líder en este Issue.